### PR TITLE
feat: enhance app management allow app 'drop-in'

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -134,6 +134,10 @@
   function devShown(id) { return (((config.settings || {}).shownDevApps) || []).includes(id); }
   function devEnabled() { return !!((config.settings || {}).devApps); }
   function appVisible(a) { return a && a.dev ? devShown(a.id) : !appHidden(a.id); }
+  async function refreshApps() {
+    try { appDefs = await configApi.getApps(); } catch (e) { appDefs = []; }
+    render();
+  }
 
   async function ensureAppIcon(value) {
     if (!value || Object.prototype.hasOwnProperty.call(appIconCache, value)) return;
@@ -554,10 +558,10 @@
     const el = document.getElementById('gridmeta');
     el.innerHTML = `
       <div class="row"><label>Name</label><input id="gName" value="${esc(g.name)}"></div>
-      <div class="row"><label>App</label><select id="gApp">
+      <div class="row"><label>App</label><select id="gApp" style="flex:1;width:auto">
         <option value="">— choose an app —</option>
         ${appDefs.filter(a => a.id === g.app || appVisible(a)).map(a => `<option value="${esc(a.id)}" ${a.id === g.app ? 'selected' : ''}>${esc(a.name)}</option>`).join('')}
-      </select></div>
+      </select><button id="refreshApps" type="button" title="Reload app manifests">Refresh</button></div>
       <div id="appOpts"></div>
       ${rotRowHtml(g)}
       ${shortcutRowHtml(g)}
@@ -566,6 +570,7 @@
       <p class="hint">${def ? esc(def.name) + ' runs locally and shows full-screen on the panel.' : 'Pick an app, then set its options below.'}</p>`;
     document.getElementById('gName').oninput = e => { g.name = e.target.value; renderGrids(); markDirty(); };
     document.getElementById('gApp').onchange = e => { setApp(g, e.target.value); render(); markDirty(); };
+    document.getElementById('refreshApps').onclick = refreshApps;
     document.getElementById('gDelete').onclick = deleteCurrentPage;
     wireRotRow(g); wireShortcutRow(g); wireAdvRow(g);
     renderAppOpts(g, def);

--- a/app/main.js
+++ b/app/main.js
@@ -251,11 +251,13 @@ function appCatalog() {
       warnAppManifest('dup:' + id, 'skipping duplicate app id: ' + id);
       return;
     }
+    const serverEntry = safeAppEntry(manifest.server);
     const def = Object.assign({}, manifest, {
       id,
       name: manifest.name || id,
       file: entry,
       entry,
+      server: serverEntry || undefined,
       served: !!manifest.served,
       options: Array.isArray(manifest.options) ? manifest.options : [],
       _folder: true,
@@ -263,7 +265,7 @@ function appCatalog() {
     });
     apps.push(def);
     ids.add(id);
-    if (def.served) servedApps[id] = { root: appDir, proxy: manifest.proxy || null };
+    if (def.served) servedApps[id] = { root: appDir, proxy: manifest.proxy || null, server: serverEntry ? path.join(appDir, serverEntry) : null };
   });
   return { apps, servedApps };
 }
@@ -296,13 +298,13 @@ function appPageUrl(page) {
   if (!def) return 'about:blank';
   if (def.served) {                                                          // served by the local server (live data, same-origin fetch, grid launch)
     const opts = page.options || {};                                         // non-secret options only; secrets are served by /app-config
-    const qs = [appOptionQuery(def, opts, o => o.type !== 'secret'), themeParams(page)].filter(Boolean).join('&');
+    const qs = [appOptionQuery(def, opts, o => o.type !== 'secret' && !o.serverOnly), themeParams(page)].filter(Boolean).join('&');
     if (def._folder) return 'http://127.0.0.1:' + serverPort + '/apps/' + encodeURIComponent(def.id) + '/' + appEntryUrlPath(def.entry || def.file) + (qs ? '?' + qs : '');
     return 'http://127.0.0.1:' + serverPort + '/' + def.id + (qs ? '?' + qs : '');
   }
   const file = def._folder ? path.join(def._dir, def.entry || def.file) : path.join(APPS_DIR, def.file);
   const opts = page.options || {};
-  const hash = [appOptionQuery(def, opts, o => o.type !== 'secret'), themeParams(page)].filter(Boolean).join('&');
+  const hash = [appOptionQuery(def, opts, o => o.type !== 'secret' && !o.serverOnly), themeParams(page)].filter(Boolean).join('&');
   return pathToFileURL(file).href + (hash ? '#' + hash : '');
 }
 function activeServedAppConfig(appId) {

--- a/app/main.js
+++ b/app/main.js
@@ -194,11 +194,82 @@ function handleDashboardPermissionRequest(wc, permission, cb, details) {
   return cb(false);
 }
 
-// Bundled local apps (apps/apps.json) — name, file, and an options schema the editor renders.
-function loadApps() {
-  try { return JSON.parse(fs.readFileSync(path.join(APPS_DIR, 'apps.json'), 'utf8')); }
-  catch (e) { console.log('apps manifest load error:', e.message); return []; }
+const SAFE_APP_ID = /^[a-z0-9][a-z0-9_-]*$/;
+const appManifestWarnings = new Set();
+function warnAppManifest(key, message) {
+  if (appManifestWarnings.has(key)) return;
+  appManifestWarnings.add(key);
+  console.log(message);
 }
+function safeAppEntry(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const rel = value.trim().replace(/\\/g, '/');
+  if (rel.includes('..') || rel.startsWith('/') || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(rel) || path.isAbsolute(rel)) return null;
+  return rel;
+}
+function appEntryUrlPath(entry) { return String(entry || '').split('/').map(encodeURIComponent).join('/'); }
+function readLegacyApps() {
+  try {
+    const apps = JSON.parse(fs.readFileSync(path.join(APPS_DIR, 'apps.json'), 'utf8'));
+    return Array.isArray(apps) ? apps : [];
+  } catch (e) { console.log('apps manifest load error:', e.message); return []; }
+}
+function readFolderAppManifest(appDir) {
+  for (const name of ['app.json', 'manifest.json']) {
+    const manifestPath = path.join(appDir, name);
+    try {
+      if (fs.existsSync(manifestPath)) return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    } catch (e) {
+      warnAppManifest('parse:' + manifestPath, 'app manifest load error: ' + manifestPath + ' - ' + e.message);
+      return null;
+    }
+  }
+  return null;
+}
+function appCatalog() {
+  const apps = readLegacyApps();
+  const ids = new Set(apps.map(a => a && a.id).filter(Boolean));
+  const servedApps = {};
+  let entries = [];
+  try { entries = fs.readdirSync(APPS_DIR, { withFileTypes: true }); }
+  catch (e) { return { apps, servedApps }; }
+  entries.filter(d => d.isDirectory()).forEach(d => {
+    const appDir = path.join(APPS_DIR, d.name);
+    const manifest = readFolderAppManifest(appDir);
+    if (!manifest) return;
+    const id = typeof manifest.id === 'string' ? manifest.id.trim() : '';
+    if (!SAFE_APP_ID.test(id)) {
+      warnAppManifest('id:' + appDir, 'skipping app folder with invalid id: ' + appDir);
+      return;
+    }
+    const entry = safeAppEntry(manifest.entry || manifest.file);
+    if (!entry) {
+      warnAppManifest('entry:' + appDir, 'skipping app folder with invalid entry: ' + id);
+      return;
+    }
+    if (ids.has(id)) {
+      warnAppManifest('dup:' + id, 'skipping duplicate app id: ' + id);
+      return;
+    }
+    const def = Object.assign({}, manifest, {
+      id,
+      name: manifest.name || id,
+      file: entry,
+      entry,
+      served: !!manifest.served,
+      options: Array.isArray(manifest.options) ? manifest.options : [],
+      _folder: true,
+      _dir: appDir,
+    });
+    apps.push(def);
+    ids.add(id);
+    if (def.served) servedApps[id] = { root: appDir, proxy: manifest.proxy || null };
+  });
+  return { apps, servedApps };
+}
+// Bundled local apps (apps/apps.json) plus drop-in app folders under apps/<id>/.
+function loadApps() { return appCatalog().apps; }
+function discoveredServedApps() { return appCatalog().servedApps; }
 // Secret-at-rest store: encrypts the secret-typed config fields (dashboard tokens / Basic passwords /
 // custom header values / app secret options) in config.json via Electron safeStorage. The in-memory
 // `config` stays plaintext; encryption happens only at the disk boundary (saveConfig). safeStorage
@@ -226,9 +297,10 @@ function appPageUrl(page) {
   if (def.served) {                                                          // served by the local server (live data, same-origin fetch, grid launch)
     const opts = page.options || {};                                         // non-secret options only; secrets are served by /app-config
     const qs = [appOptionQuery(def, opts, o => o.type !== 'secret'), themeParams(page)].filter(Boolean).join('&');
+    if (def._folder) return 'http://127.0.0.1:' + serverPort + '/apps/' + encodeURIComponent(def.id) + '/' + appEntryUrlPath(def.entry || def.file) + (qs ? '?' + qs : '');
     return 'http://127.0.0.1:' + serverPort + '/' + def.id + (qs ? '?' + qs : '');
   }
-  const file = path.join(APPS_DIR, def.file);
+  const file = def._folder ? path.join(def._dir, def.entry || def.file) : path.join(APPS_DIR, def.file);
   const opts = page.options || {};
   const hash = [appOptionQuery(def, opts, o => o.type !== 'secret'), themeParams(page)].filter(Boolean).join('&');
   return pathToFileURL(file).href + (hash ? '#' + hash : '');
@@ -751,7 +823,7 @@ app.whenReady().then(async () => {
   // Lazy-required so a metrics/load failure can never crash the rest of the app.
   try {
     sysserver = require('./sysserver');
-    serverPort = await sysserver.start({ onMedia: mediaKey, onLaunch: onMusicLaunch, getMusicTiles, getAppConfig: activeServedAppConfig });
+    serverPort = await sysserver.start({ onMedia: mediaKey, onLaunch: onMusicLaunch, getMusicTiles, getAppConfig: activeServedAppConfig, onOpenExternal: openExternalUrl, appFolders: discoveredServedApps() });
     ensureSystemViewPage(serverPort); ensureMusicPage();
     const env = loadEnv(); haschedule.configure({ url: env.HA_URL, token: env.HA_TOKEN });   // HA Schedule dev app creds
     console.log('SystemView + Music on http://127.0.0.1:' + serverPort + (env.HA_URL ? ' · HA Schedule -> ' + env.HA_URL : ''));
@@ -808,7 +880,12 @@ app.whenReady().then(async () => {
   });
   ipcMain.on('openExternal', (e, url) => { if (!isFrom(e, panelWin) && !isFrom(e, configWin)) return; openExternalUrl(url); });
   ipcMain.handle('getConfig', (e) => isFrom(e, configWin) ? config : null);
-  ipcMain.handle('getApps', (e) => isFrom(e, configWin) ? loadApps() : []);
+  ipcMain.handle('getApps', (e) => {
+    if (!isFrom(e, configWin)) return [];
+    const catalog = appCatalog();
+    try { if (sysserver && sysserver.setAppFolders) sysserver.setAppFolders(catalog.servedApps); } catch (er) {}
+    return catalog.apps;
+  });
   ipcMain.on('saveConfigFromEditor', (e, newCfg) => {
     if (!isFrom(e, configWin) || !newCfg || typeof newCfg !== 'object' || !Array.isArray(newCfg.grids)) return;
     const active = config.activeGridId;                          // the knob owns the live page — editor edits never change it

--- a/app/sysserver.js
+++ b/app/sysserver.js
@@ -57,6 +57,7 @@ let server = null, onMedia = null, onLaunch = null, getMusicTiles = null, getApp
 let sysHtml = FALLBACK, musicHtml = FALLBACK, chatHtml = FALLBACK, hascheduleHtml = FALLBACK;
 const staticAssets = {};   // request path -> { body, type }; populated at start()
 let appFolders = {};        // drop-in served app id -> { root, proxy }; supplied by main.js
+const appServers = {};      // app id -> required server module
 
 function headers(type) { return { 'Content-Type': type, 'Cache-Control': 'no-store', 'Content-Security-Policy': LOCAL_APP_CSP }; }
 function html(res, body) { res.writeHead(200, headers('text/html; charset=utf-8')); res.end(body); }
@@ -64,6 +65,7 @@ function json(res, obj) { res.writeHead(200, headers('application/json; charset=
 function done(res, ok) { res.writeHead(ok ? 200 : 400, headers('application/json')); res.end(JSON.stringify({ ok: !!ok })); }
 function setAppFolders(folders) {
   appFolders = {};
+  Object.keys(appServers).forEach(id => { if (!folders || !folders[id]) delete appServers[id]; });
   Object.entries(folders || {}).forEach(([id, value]) => {
     appFolders[id] = typeof value === 'string' ? { root: value, proxy: null } : Object.assign({}, value || {});
   });
@@ -128,6 +130,11 @@ function queryValue(full, key) {
   try { return new URL(full, 'http://127.0.0.1').searchParams.get(key) || ''; }
   catch (e) { return ''; }
 }
+function queryObject(full) {
+  const out = {};
+  try { new URL(full, 'http://127.0.0.1').searchParams.forEach((value, key) => { out[key] = value; }); } catch (e) {}
+  return out;
+}
 function privateHost(hostname) {
   const h = String(hostname || '').toLowerCase();
   if (h === 'localhost' || h === '0.0.0.0' || h === '::1' || h.endsWith('.local')) return true;
@@ -142,10 +149,24 @@ function proxyAllowed(appId, targetUrl) {
   if (proxy.methods && Array.isArray(proxy.methods) && !proxy.methods.includes('GET')) return false;
   let target;
   try { target = new URL(targetUrl); } catch (e) { return false; }
-  if ((target.protocol !== 'http:' && target.protocol !== 'https:') || privateHost(target.hostname)) return false;
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') return false;
   const allow = Array.isArray(proxy.allow) ? proxy.allow : [];
   if (!allow.length) return false;
   return allow.some(rule => {
+    if (rule.option) {
+      let cfg;
+      try { cfg = getAppConfig && getAppConfig(appId); } catch (e) {}
+      const baseValue = cfg && cfg.options && cfg.options[rule.option];
+      if (!baseValue) return false;
+      try {
+        const base = new URL(String(baseValue).replace(/\/+$/, '') + '/');
+        const basePath = base.pathname === '/' ? '/' : base.pathname.replace(/\/+$/, '/') ;
+        return target.origin === base.origin && (basePath === '/' || target.pathname === basePath.slice(0, -1) || target.pathname.startsWith(basePath));
+      } catch (e) {
+        return false;
+      }
+    }
+    if (privateHost(target.hostname)) return false;
     try { return new RegExp(rule.pattern).test(target.href); }
     catch (e) { return false; }
   });
@@ -203,10 +224,48 @@ function serveAppProxy(req, res, full) {
     res.end(result.body);
   });
 }
-function serveAppApi(req, res, full, url) {
+function appOptions(appId) {
+  try {
+    const cfg = getAppConfig && getAppConfig(appId);
+    return cfg && cfg.options || {};
+  } catch (e) {
+    return {};
+  }
+}
+function appServer(appId) {
+  const appInfo = appFolders[appId];
+  if (!appInfo || !appInfo.server) return null;
+  if (appServers[appId]) return appServers[appId];
+  const root = path.resolve(appInfo.root);
+  const serverFile = path.resolve(appInfo.server);
+  if (serverFile !== root && !serverFile.startsWith(root + path.sep)) return null;
+  try {
+    appServers[appId] = require(serverFile);
+    return appServers[appId];
+  } catch (e) {
+    console.log('app server load error:', appId, '-', e.message);
+    return null;
+  }
+}
+async function serveAppApi(req, res, full, url) {
   const appId = requestingAppId(req);
   const action = url.slice('/app-api/'.length);
-  if (!appId || action !== 'open') { return done(res, false); }
+  if (!appId || !action) { return done(res, false); }
+  const mod = appServer(appId);
+  if (mod && typeof mod.handle === 'function') {
+    try {
+      const result = await mod.handle(action, { appId, query: queryObject(full), options: appOptions(appId) });
+      const status = result && result.ok === false && result.error === 'unknown action' ? 400 : 200;
+      res.writeHead(status, headers('application/json; charset=utf-8'));
+      res.end(JSON.stringify(result == null ? { ok: true } : result));
+      return;
+    } catch (e) {
+      res.writeHead(500, headers('application/json; charset=utf-8'));
+      res.end(JSON.stringify({ ok: false, error: e.message || 'app server failed' }));
+      return;
+    }
+  }
+  if (action !== 'open') { return done(res, false); }
   const target = queryValue(full, 'url');
   let ok = false;
   try {
@@ -257,6 +316,11 @@ async function handler(req, res) {
   if (url === '/app-config') {
     const m = /[?&]app=([A-Za-z0-9_-]+)/.exec(full);
     const cfg = (m && getAppConfig) ? getAppConfig(m[1]) : null;
+    return cfg ? json(res, cfg) : done(res, false);
+  }
+  if (url === '/app-proxy/config') {
+    const appId = requestingAppId(req);
+    const cfg = appId && getAppConfig ? getAppConfig(appId) : null;
     return cfg ? json(res, cfg) : done(res, false);
   }
   if (url === '/app-proxy') return serveAppProxy(req, res, full);

--- a/app/sysserver.js
+++ b/app/sysserver.js
@@ -12,8 +12,10 @@
  *   GET /musictiles  -> the active Music page's embedded 2x2 grid (resolved icons)
  *   GET /media/<cmd> -> transport (play/pause/next/prev) via onMedia
  *   GET /launch?i=N  -> launch the active Music grid's tile N via onLaunch (runAction)
+ *   GET /apps/<id>/… -> static files for discovered served drop-in apps
  */
 const http = require('http');
+const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const metrics = require('./sysmetrics');
@@ -51,14 +53,168 @@ const STATIC_FILES = {
   '/haschedule-ui.js': 'application/javascript; charset=utf-8',
 };
 
-let server = null, onMedia = null, onLaunch = null, getMusicTiles = null, getAppConfig = null;
+let server = null, onMedia = null, onLaunch = null, getMusicTiles = null, getAppConfig = null, onOpenExternal = null;
 let sysHtml = FALLBACK, musicHtml = FALLBACK, chatHtml = FALLBACK, hascheduleHtml = FALLBACK;
 const staticAssets = {};   // request path -> { body, type }; populated at start()
+let appFolders = {};        // drop-in served app id -> { root, proxy }; supplied by main.js
 
 function headers(type) { return { 'Content-Type': type, 'Cache-Control': 'no-store', 'Content-Security-Policy': LOCAL_APP_CSP }; }
 function html(res, body) { res.writeHead(200, headers('text/html; charset=utf-8')); res.end(body); }
 function json(res, obj) { res.writeHead(200, headers('application/json; charset=utf-8')); res.end(JSON.stringify(obj)); }
 function done(res, ok) { res.writeHead(ok ? 200 : 400, headers('application/json')); res.end(JSON.stringify({ ok: !!ok })); }
+function setAppFolders(folders) {
+  appFolders = {};
+  Object.entries(folders || {}).forEach(([id, value]) => {
+    appFolders[id] = typeof value === 'string' ? { root: value, proxy: null } : Object.assign({}, value || {});
+  });
+}
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.htm': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+};
+function mimeFor(file) { return MIME[path.extname(file).toLowerCase()] || 'application/octet-stream'; }
+function serveDropInApp(url, res) {
+  const m = /^\/apps\/([A-Za-z0-9_-]+)\/(.+)$/.exec(url);
+  if (!m) return false;
+  const appInfo = appFolders[m[1]];
+  const root = appInfo && appInfo.root;
+  if (!root) { res.writeHead(404); res.end(); return true; }
+  let rel;
+  try { rel = decodeURIComponent(m[2]).replace(/\\/g, '/'); }
+  catch (e) { res.writeHead(400); res.end(); return true; }
+  if (!rel || rel.includes('..') || rel.startsWith('/') || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(rel) || path.isAbsolute(rel)) {
+    res.writeHead(403); res.end(); return true;
+  }
+  const absRoot = path.resolve(root);
+  const file = path.resolve(absRoot, rel);
+  if (file !== absRoot && !file.startsWith(absRoot + path.sep)) { res.writeHead(403); res.end(); return true; }
+  fs.readFile(file, (err, body) => {
+    if (err) { res.writeHead(err.code === 'ENOENT' ? 404 : 500); res.end(); return; }
+    res.writeHead(200, headers(mimeFor(file)));
+    res.end(body);
+  });
+  return true;
+}
+
+function requestingAppId(req) {
+  const ref = req.headers.referer || req.headers.referrer || '';
+  if (!ref) return null;
+  try {
+    const u = new URL(ref);
+    if (u.protocol !== 'http:' || !(u.hostname === '127.0.0.1' || u.hostname === 'localhost') || Number(u.port) !== loopbackPort()) return null;
+    const m = /^\/apps\/([A-Za-z0-9_-]+)\//.exec(u.pathname);
+    return m && appFolders[m[1]] ? m[1] : null;
+  } catch (e) {
+    return null;
+  }
+}
+function queryValue(full, key) {
+  try { return new URL(full, 'http://127.0.0.1').searchParams.get(key) || ''; }
+  catch (e) { return ''; }
+}
+function privateHost(hostname) {
+  const h = String(hostname || '').toLowerCase();
+  if (h === 'localhost' || h === '0.0.0.0' || h === '::1' || h.endsWith('.local')) return true;
+  if (/^127(?:\.\d{1,3}){3}$/.test(h) || /^10(?:\.\d{1,3}){3}$/.test(h) || /^192\.168(?:\.\d{1,3}){2}$/.test(h)) return true;
+  const m = /^172\.(\d{1,3})(?:\.\d{1,3}){2}$/.exec(h);
+  return !!(m && Number(m[1]) >= 16 && Number(m[1]) <= 31);
+}
+function proxyAllowed(appId, targetUrl) {
+  const appInfo = appFolders[appId];
+  const proxy = appInfo && appInfo.proxy;
+  if (!proxy) return false;
+  if (proxy.methods && Array.isArray(proxy.methods) && !proxy.methods.includes('GET')) return false;
+  let target;
+  try { target = new URL(targetUrl); } catch (e) { return false; }
+  if ((target.protocol !== 'http:' && target.protocol !== 'https:') || privateHost(target.hostname)) return false;
+  const allow = Array.isArray(proxy.allow) ? proxy.allow : [];
+  if (!allow.length) return false;
+  return allow.some(rule => {
+    try { return new RegExp(rule.pattern).test(target.href); }
+    catch (e) { return false; }
+  });
+}
+function verifySslFor(appId) {
+  const appInfo = appFolders[appId] || {};
+  const opt = appInfo.proxy && appInfo.proxy.verifySslOption;
+  if (!opt || !getAppConfig) return true;
+  try {
+    const cfg = getAppConfig(appId);
+    return !cfg || !cfg.options || cfg.options[opt] !== false;
+  } catch (e) {
+    return true;
+  }
+}
+function proxyFetch(targetUrl, verifySsl, redirects, cb) {
+  let target;
+  try { target = new URL(targetUrl); } catch (e) { return cb(e); }
+  const lib = target.protocol === 'https:' ? https : http;
+  const req = lib.get(target, {
+    timeout: 12000,
+    headers: { 'User-Agent': 'open-quake/NewsSpotlight', 'Accept': 'application/rss+xml, application/xml, text/xml, text/html, */*' },
+    agent: target.protocol === 'https:' && !verifySsl ? new https.Agent({ rejectUnauthorized: false }) : undefined,
+  }, upstream => {
+    const location = upstream.headers.location;
+    if (location && upstream.statusCode >= 300 && upstream.statusCode < 400 && redirects > 0) {
+      upstream.resume();
+      let next;
+      try { next = new URL(location, target).href; } catch (e) { return cb(e); }
+      return proxyFetch(next, verifySsl, redirects - 1, cb);
+    }
+    const chunks = [];
+    let size = 0;
+    upstream.on('data', chunk => {
+      size += chunk.length;
+      if (size > 5 * 1024 * 1024) req.destroy(new Error('response too large'));
+      else chunks.push(chunk);
+    });
+    upstream.on('end', () => cb(null, {
+      status: upstream.statusCode || 502,
+      type: upstream.headers['content-type'] || 'application/octet-stream',
+      body: Buffer.concat(chunks),
+    }));
+  });
+  req.on('timeout', () => req.destroy(new Error('request timed out')));
+  req.on('error', cb);
+}
+function serveAppProxy(req, res, full) {
+  const appId = requestingAppId(req);
+  const target = queryValue(full, 'url');
+  if (!appId || !proxyAllowed(appId, target)) { res.writeHead(403); res.end(); return; }
+  proxyFetch(target, verifySslFor(appId), 3, (err, result) => {
+    if (err) { res.writeHead(502, headers('text/plain; charset=utf-8')); res.end(err.message || 'proxy failed'); return; }
+    res.writeHead(result.status, headers(result.type));
+    res.end(result.body);
+  });
+}
+function serveAppApi(req, res, full, url) {
+  const appId = requestingAppId(req);
+  const action = url.slice('/app-api/'.length);
+  if (!appId || action !== 'open') { return done(res, false); }
+  const target = queryValue(full, 'url');
+  let ok = false;
+  try {
+    const parsed = new URL(target);
+    ok = (parsed.protocol === 'http:' || parsed.protocol === 'https:') && typeof onOpenExternal === 'function' && !!onOpenExternal(parsed.href);
+  } catch (e) {}
+  return done(res, ok);
+}
 
 // Loopback-only hardening. The server binds 127.0.0.1, but a malicious web page (or a DNS-rebinding
 // hostname that resolves to 127.0.0.1) can still try to reach it. hostOk() rejects any request whose
@@ -93,6 +249,7 @@ async function handler(req, res) {
   if (url === '/haschedule') return html(res, hascheduleHtml);
   const asset = staticAssets[url];
   if (asset) { res.writeHead(200, headers(asset.type)); return res.end(asset.body); }
+  if (serveDropInApp(url, res)) return;
   // Below here: side effects (/launch, /media), live data (/metrics, /nowplaying, /musictiles), or
   // secrets (/app-config). Require the request to originate from our own served page — not a
   // cross-site fetch, image, form, or navigation.
@@ -102,6 +259,8 @@ async function handler(req, res) {
     const cfg = (m && getAppConfig) ? getAppConfig(m[1]) : null;
     return cfg ? json(res, cfg) : done(res, false);
   }
+  if (url === '/app-proxy') return serveAppProxy(req, res, full);
+  if (url.indexOf('/app-api/') === 0) return serveAppApi(req, res, full, url);
   if (url === '/metrics') return json(res, metrics.getSnapshot());
   if (url === '/nowplaying') return json(res, nowplaying.getSnapshot());
   if (url === '/haschedule-data') return json(res, haschedule.getSnapshot());
@@ -134,6 +293,8 @@ function start(opts) {
   onLaunch = opts.onLaunch || null;
   getMusicTiles = opts.getMusicTiles || null;
   getAppConfig = opts.getAppConfig || null;
+  onOpenExternal = opts.onOpenExternal || null;
+  setAppFolders(opts.appFolders);
   nowplaying.setProvider(opts.getNowPlaying || null);
   return new Promise((resolve, reject) => {
     if (server) return resolve(server.address().port);
@@ -167,4 +328,4 @@ function stop() {
   if (server) { try { server.close(); } catch (e) {} server = null; }
 }
 
-module.exports = { start, stop, setActivePage };
+module.exports = { start, stop, setActivePage, setAppFolders };

--- a/docs/app-template/app.js
+++ b/docs/app-template/app.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function readOptions() {
+  const raw = window.location.hash ? window.location.hash.slice(1) : window.location.search.slice(1);
+  return new URLSearchParams(raw);
+}
+
+const opts = readOptions();
+const message = opts.get('message');
+if (message) document.getElementById('message').textContent = message;

--- a/docs/app-template/app.json
+++ b/docs/app-template/app.json
@@ -1,0 +1,14 @@
+{
+  "id": "my-app",
+  "name": "My App",
+  "entry": "index.html",
+  "served": false,
+  "options": [
+    {
+      "key": "message",
+      "label": "Message",
+      "type": "text",
+      "default": "Hello from a drop-in app"
+    }
+  ]
+}

--- a/docs/app-template/index.html
+++ b/docs/app-template/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>My App</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1 id="message">My App</h1>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/app-template/style.css
+++ b/docs/app-template/style.css
@@ -1,0 +1,30 @@
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #101820;
+  color: #f4f8fb;
+  font-family: "Segoe UI", system-ui, sans-serif;
+}
+
+main {
+  width: min(100vw, 1920px);
+  height: min(100vh, 480px);
+  display: grid;
+  place-items: center;
+}
+
+h1 {
+  margin: 0;
+  font-size: 48px;
+  font-weight: 700;
+}

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -70,6 +70,29 @@ in the editor to reload manifests.
   that need same-origin `fetch`, browser APIs that require HTTP, or multiple
   static assets served through the same origin.
 
+Served drop-in apps can also declare host-side helpers:
+
+```json
+{
+  "server": "server.js",
+  "proxy": {
+    "methods": ["GET"],
+    "verifySslOption": "verifySsl",
+    "allow": [{ "option": "host" }]
+  }
+}
+```
+
+- `server` loads a local Node module from the app folder. It should export
+  `handle(action, context)`. The page calls it with `/app-api/<action>`.
+- `context.options` contains the active app options, including options marked
+  `"serverOnly": true` and secret options.
+- `"serverOnly": true` keeps an option out of the page URL while still making it
+  available to the server adapter and `/app-proxy/config`.
+- `/app-proxy?url=...` is available only to the requesting app page and only for
+  URLs allowed by the app manifest. `{ "option": "host" }` allows requests to the
+  configured host origin, including LAN devices.
+
 See `docs/app-template/` for a minimal starting point.
 
 ## Legacy bundled apps

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -1,9 +1,10 @@
-# Bundled apps
+# Apps
 
-Bundled local web apps live in `apps/`, listed in `apps/apps.json` (each with a
-name, file, and an options schema). In the editor, **+ App** adds an app page:
-pick the app and set its options — open-quake loads it full-screen on the panel,
-no server and no hand-typed URLs.
+Local web apps live in `apps/`. Legacy bundled apps are still listed in
+`apps/apps.json`; new apps can also be dropped in as self-contained folders under
+`apps/<app-id>/` with their own manifest. In the editor, **+ App** adds an app
+page: pick the app and set its options, and open-quake loads it full-screen on
+the panel with no hand-typed URLs.
 
 Included apps:
 - **Flip Clock** — split-flap animation, 12/24-hour, optional seconds, and a corner
@@ -20,7 +21,58 @@ Included apps:
 
 ![Configuring the Flip Clock app in the editor](shots/editor-clock.png)
 
-## Write your own
+## Drop-in folder apps
+
+Create a folder under `apps/`:
+
+```text
+apps/
+  my-app/
+    app.json
+    index.html
+    style.css
+    app.js
+```
+
+The manifest can be named `app.json` or `manifest.json`:
+
+```json
+{
+  "id": "my-app",
+  "name": "My App",
+  "entry": "index.html",
+  "served": false,
+  "options": []
+}
+```
+
+Rules:
+
+- `id` must start with a lowercase letter or digit and then use only lowercase
+  letters, digits, `_`, or `-`.
+- `entry` must be a relative file path inside the app folder and must not
+  contain `..`.
+- Duplicate ids are skipped; bundled `apps/apps.json` entries win.
+- `options` uses the same schema as bundled apps. The editor stores each option
+  on the app page and passes non-secret values to the app at launch.
+
+After adding or editing a folder app, click **Refresh** beside the App dropdown
+in the editor to reload manifests.
+
+## Static and served modes
+
+- **Static (`"served": false`)** — open-quake loads `entry` directly via
+  `file://` from the app folder. Options are passed in the URL hash:
+  `index.html#color=red`. Static apps are best for self-contained HTML/CSS/JS.
+- **Served (`"served": true`)** — open-quake serves the app folder on the local
+  loopback server at `http://127.0.0.1:<port>/apps/<id>/<entry>`. Options are
+  passed as normal query parameters: `index.html?color=red`. Use this for apps
+  that need same-origin `fetch`, browser APIs that require HTTP, or multiple
+  static assets served through the same origin.
+
+See `docs/app-template/` for a minimal starting point.
+
+## Legacy bundled apps
 
 Two kinds of bundled app:
 


### PR DESCRIPTION
- Added async function to refresh app definitions from the config API.
- Integrated a refresh button in the app selection dropdown for reloading app manifests.
- Improved app catalog loading to include drop-in app folders.
- Enhanced server to serve static files for discovered drop-in apps.
- Updated IPC handler to manage served app folders and configurations.