### PR TITLE
security: permit ws/wss in local app Content-Security-Policy

### DIFF
--- a/app/sysserver.js
+++ b/app/sysserver.js
@@ -33,7 +33,7 @@ const LOCAL_APP_CSP = [
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: file: http: https:",
   "font-src 'self' data:",
-  "connect-src 'self' http: https:",
+  "connect-src 'self' http: https: ws: wss:",
   "media-src 'self' blob: data:",
   "object-src 'none'",
   "base-uri 'none'",


### PR DESCRIPTION
"This PR updates the local app server Content-Security-Policy (CSP) headers to permit WebSocket connections (ws: and wss:). This is required for served drop-in applications that need to communicate with local daemon processes or external hardware interfaces."