### PR TITLE
Live Translate panel app (Tier 1: live English captions)

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -402,7 +402,7 @@
       <div class="row" style="margin-top:8px"><label style="width:auto">Knob</label>
         <label class="iconopt" style="width:auto"><input type="checkbox" id="gKnobOn" ${g.knobOverride ? 'checked' : ''}> Override</label></div>
       ${g.knobOverride ? `<div class="row"><label style="width:auto">Turn / Click / Dbl</label>${knobSelHtml('gKnobTurn', KNOB_TURN_OPTS, (g.knob && g.knob.turn) || 'pages')} ${knobSelHtml('gKnobClick', KNOB_CLICK_OPTS, (g.knob && g.knob.click) || 'rotation')} ${knobSelHtml('gKnobDblclick', KNOB_DBLCLICK_OPTS, (g.knob && g.knob.dblclick) || 'selector')}</div>` : ''}
-      ${(VOICE_APPS.includes(g.app) || g.app === 'lucidtype') ? `
+      ${(VOICE_APPS.includes(g.app) || g.app === 'lucidtype' || g.app === 'livetranslate') ? `
       <div class="row" style="margin-top:8px"><label style="width:auto">STT / TTS</label>
         <label class="iconopt" style="width:auto"><input type="checkbox" id="gVoiceOn" ${g.options && g.options.voiceOverride ? 'checked' : ''}> Override default TTS/STT servers</label></div>
       ${g.options && g.options.voiceOverride ? `

--- a/app/livetranslate-host.js
+++ b/app/livetranslate-host.js
@@ -1,0 +1,122 @@
+'use strict';
+// Lightweight HOST for the "Live Translate" panel app (Tier 1). Unlike the voice-panel host
+// (voicepanel-host.js) it has NO LLM adapter and none of the turn/SSE/speech machinery -- it only
+// turns one VAD-trimmed mic utterance (raw 16 kHz/16-bit/mono PCM, matching claudevoice-vad.js) into
+// text via the configured Wyoming STT endpoint, and optionally appends each finalized line to a
+// running text file.
+//
+// "Translation to English" is NOT done here: it happens inside wyoming-faster-whisper when that STT
+// server is launched with `--whisper-task translate` (a server-global flag -- confirmed per-request
+// task selection is not supported). So the recommended setup points THIS page's STT override
+// (grid.options.voiceOverride + voiceSttHost/voiceSttPort) at a translate-mode Whisper endpoint
+// (e.g. a second port on the tts-stt-windows helper). This host is task-agnostic and simply shows
+// whatever text the STT returns -- English when the endpoint is in translate mode, verbatim otherwise.
+//
+// deps (reuses main.js's voicePanelDeps('livetranslate')):
+//   voiceEndpoints() -> { sttHost, sttPort, ... }   activeServedAppConfig(appId)
+//   activeGrid()   saveConfig()   getDocumentsPath()
+const fs = require('fs');
+const path = require('path');
+const wyoming = require('./claudevoice-wyoming');       // pure Wyoming STT/TTS protocol client
+const { isSttNoisePhrase } = require('./voiceConfig');  // drops whisper's near-silence hallucinations
+
+function truthy(v) { return v === true || v === '1' || v === 'true'; }
+
+// Panel-editable options, validated + normalized to the string form stored in config.json's g.options
+// (so they survive app restarts and match how the query-string delivery re-reads them).
+const PANEL_OPTIONS = {
+  saveToFile: v => (v === true || v === '1' || v === false || v === '0' || v === 'true' || v === 'false')
+    ? (truthy(v) ? '1' : '0') : null,
+  vadHangoverMs: v => { const n = parseInt(v, 10); return n >= 400 && n <= 2500 ? String(n) : null; },
+  // Mic pick is stored as a LABEL, not a deviceId (Chromium salts ids per origin, and the served
+  // origin's port changes every launch); the page re-matches label -> id at startup. '' = default.
+  micDevice: v => typeof v === 'string' && v.length <= 200 ? v : null,
+};
+
+function createLiveTranslateHost({ appId = 'livetranslate', log, deps }) {
+  const say = log || (() => {});
+  let currentSavePath = '';   // file the current Save-to-file session appends to (stamped on first line)
+
+  function pageOptions() {
+    const cfg = deps.activeServedAppConfig(appId);
+    return (cfg && cfg.options) || null;
+  }
+  // Two-digit-padded local timestamp for the save filename (app code, so Date is fine to use here).
+  function stamp() {
+    const d = new Date(), p = n => String(n).padStart(2, '0');
+    return d.getFullYear() + '-' + p(d.getMonth() + 1) + '-' + p(d.getDate()) + '-' +
+      p(d.getHours()) + '-' + p(d.getMinutes()) + '-' + p(d.getSeconds());
+  }
+  function saveFolder() { return path.join(deps.getDocumentsPath() || '', 'OpenQuake Translations'); }
+
+  // Append one finalized line to the running file when Save-to-file is on. One file per save session:
+  // the name is stamped when the first line lands and reused until saving is toggled off.
+  function maybeSave(line) {
+    const o = pageOptions();
+    if (!o || !truthy(o.saveToFile)) { currentSavePath = ''; return; }
+    try {
+      const dir = saveFolder();
+      fs.mkdirSync(dir, { recursive: true });
+      if (!currentSavePath) currentSavePath = path.join(dir, 'translation-' + stamp() + '.txt');
+      fs.appendFileSync(currentSavePath, line + '\r\n');
+    } catch (e) { say('Save-to-file failed: ' + e.message); }
+  }
+
+  // Transcribes one VAD-trimmed utterance via the configured wyoming-faster-whisper host/port.
+  async function transcribe(pcmBuffer) {
+    const { sttHost: host, sttPort: port } = deps.voiceEndpoints();
+    if (!host || !port) {
+      return { ok: false, error: 'STT host/port not configured (this page’s Advanced override, or Settings → TTS/STT)' };
+    }
+    try {
+      const text = await wyoming.transcribe({ host, port, audio: pcmBuffer, rate: 16000, width: 2, channels: 1, log: say });
+      if (isSttNoisePhrase(text)) { say('STT dropped a known noise-hallucination phrase: ' + JSON.stringify(text)); return { ok: true, text: '' }; }
+      const clean = String(text || '').trim();
+      if (clean) maybeSave(clean);
+      return { ok: true, text: clean };
+    } catch (e) {
+      say('STT error: ' + e.message);
+      return { ok: false, error: e.message };
+    }
+  }
+
+  // Snapshot for the page's on-load /state fetch: whether an STT endpoint is set, its host:port (for
+  // the dim source line), the target-language label, and the current save state/path.
+  function getState() {
+    const { sttHost, sttPort } = deps.voiceEndpoints();
+    const o = pageOptions() || {};
+    return {
+      ok: true,
+      status: 'idle',
+      sttConfigured: !!(sttHost && sttPort),
+      sttEndpoint: sttHost && sttPort ? (sttHost + ':' + sttPort) : '',
+      targetLangLabel: o.targetLangLabel || 'English',
+      saveToFile: truthy(o.saveToFile),
+      savePath: currentSavePath || '',
+    };
+  }
+
+  // Persist a panel-tunable option into this page's options in config.json (only when livetranslate is
+  // the active page). Toggling save OFF ends the current file so the next ON starts a fresh one.
+  function setOption(key, value) {
+    const validate = PANEL_OPTIONS[key];
+    if (!validate) return false;
+    const v = validate(value);
+    if (v == null) return false;
+    const g = deps.activeGrid();
+    if (!(g && g.kind === 'app' && g.app === appId)) return false;
+    if (!g.options) g.options = {};
+    g.options[key] = v;
+    if (key === 'saveToFile' && v === '0') currentSavePath = '';
+    deps.saveConfig();
+    return true;
+  }
+
+  return {
+    appId,
+    handlers: { transcribe, getState, setOption },
+    shutdown() {},   // nothing long-lived to tear down
+  };
+}
+
+module.exports = { createLiveTranslateHost };

--- a/app/livetranslateview.html
+++ b/app/livetranslateview.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Live Translate</title>
+<style>
+  * { box-sizing: border-box; }
+  :root { --bg:#05080d; --fg:#e8eef6; --muted:#9fb3c8; --dim:#7e93ab; --surf:#131f2c; --surf2:#0e1822;
+    --tile-bd:#233245; --accent:#7CFFB2; --danger:#ff5a5a; --warn:#ffb454; }
+  body.light { --bg:#e6ecf3; --fg:#12202c; --muted:#566573; --dim:#68798a; --surf:#f3f6f9; --surf2:#e6ecf2; --tile-bd:#c7d2dc; }
+  html, body { margin: 0; width: 100%; height: 100%; }
+  body { background: var(--bg); color: var(--fg); overflow: hidden;
+    font-family: "Segoe UI", system-ui, sans-serif; touch-action: manipulation; }
+  #wrap { display: flex; flex-direction: row; width: 100vw; height: 100vh; padding: 14px 18px 16px 24px; gap: 16px; }
+  #main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 10px; }
+
+  /* Primary: the live (English) transcript. Captions style -- clean stacked lines, newest at the
+     bottom, oldest dimmed, large for arm's-length reading. The still-transcribing utterance shows a
+     placeholder line with a blinking accent cursor. */
+  #card { flex: 1; min-height: 0; overflow-y: auto; background: var(--surf); border: 1px solid var(--tile-bd);
+    border-radius: 14px; padding: 18px 24px; display: flex; flex-direction: column; justify-content: flex-end; gap: 14px;
+    touch-action: pan-y; overscroll-behavior: contain; }
+  #empty { color: var(--dim); font-size: 20px; text-align: center; margin: auto; }
+  .line { font-size: 26px; line-height: 1.4; overflow-wrap: break-word; color: var(--muted); }
+  .line.recent { color: var(--fg); }
+  .line.live { color: var(--fg); }
+  .line.live::after { content: ""; display: inline-block; width: 12px; height: 26px; margin-left: 6px;
+    background: var(--accent); vertical-align: -4px; border-radius: 2px; animation: oqxblink 1s step-end infinite; }
+  @keyframes oqxblink { 50% { opacity: 0; } }
+
+  #statusRow { flex: 0 0 auto; display: flex; gap: 16px; align-items: baseline; min-height: 18px; user-select: none; }
+  #status { font-size: 13px; font-weight: 600; color: var(--dim); text-transform: uppercase; letter-spacing: .05em; }
+  #status.listening { color: var(--accent); }
+  #status.error { color: var(--danger); }
+  #srcInfo { font-size: 13px; color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* Control rail -- 284px, mirrors the voice apps' right panel. */
+  #rail { flex: 0 0 284px; display: flex; flex-direction: column; gap: 14px; align-items: center;
+    justify-content: space-between; user-select: none; }
+  #title { width: 100%; text-align: center; font-size: 24px; font-weight: 700; }
+  #target { width: 100%; min-height: 56px; border-radius: 14px; border: 1px solid var(--tile-bd);
+    background: var(--surf); display: flex; align-items: center; justify-content: center; gap: 10px;
+    font-size: 22px; font-weight: 700; }
+  #target .arrow { color: var(--dim); font-weight: 600; font-size: 18px; }
+  #target .lang { color: var(--accent); }
+
+  .iconBtn { position: relative; width: 116px; height: 116px; border-radius: 50%; border: 2px solid var(--tile-bd);
+    background: linear-gradient(160deg, var(--surf), var(--surf2)); cursor: pointer; color: var(--fg);
+    display: flex; align-items: center; justify-content: center; transition: transform .08s ease; }
+  .iconBtn:active { transform: scale(.92); }
+  .iconBtn svg.glyph { width: 48%; height: 48%; fill: currentColor; position: relative; z-index: 2; }
+  .iconBtn.on { border-color: var(--accent); }
+  .iconBtn.off svg.glyph { opacity: .45; }
+  .iconBtn svg.ban { display: none; }
+  .iconBtn.off svg.ban { display: block; position: absolute; inset: 6%; width: 88%; height: 88%; z-index: 3;
+    fill: none; stroke: var(--danger); stroke-width: 1.6; stroke-linecap: round; }
+  #micRipples { position: absolute; inset: 0; pointer-events: none; z-index: 1; }
+  .ripple { position: absolute; left: 50%; top: 50%; width: 90px; height: 90px; margin: -45px 0 0 -45px;
+    border: 2px solid var(--accent); border-radius: 50%; opacity: .6; animation: oqxripple 1.1s ease-out forwards; }
+  @keyframes oqxripple { from { transform: scale(.6); opacity: .6; } to { transform: scale(2.1); opacity: 0; } }
+
+  #railBtns { width: 100%; display: flex; flex-direction: column; gap: 14px; }
+  .vpBtn { width: 100%; min-height: 64px; border-radius: 14px; border: 1px solid var(--tile-bd); background: var(--surf);
+    color: var(--fg); font-size: 19px; font-weight: 600; cursor: pointer; padding: 8px 10px;
+    display: flex; align-items: center; justify-content: center; gap: 10px; }
+  .vpBtn:active { background: var(--surf2); }
+  .vpBtn .sub { font-size: 14px; font-weight: 700; color: var(--dim); }
+  .vpBtn.on { border-color: var(--accent); }
+  .vpBtn.on .sub { color: var(--accent); }
+  #srcPill { font-size: 13px; color: var(--dim); text-align: center; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; width: 100%; }
+
+  button:focus:not(:focus-visible) { outline: none; }
+
+  /* Settings overlay: pause tolerance + microphone pick (opens the device picker below). */
+  #settingsOverlay { position: fixed; inset: 0; background: rgba(0,0,0,.55); display: flex;
+    align-items: center; justify-content: center; padding: 18px; z-index: 40; user-select: none; }
+  #settingsOverlay.hidden { display: none; }
+  #settingsCard { width: min(720px, 100%); max-height: 100%; overflow: hidden; display: flex; flex-direction: column;
+    background: var(--surf); border: 1px solid var(--tile-bd); border-radius: 16px; padding: 16px 24px;
+    box-shadow: 0 12px 40px rgba(0,0,0,.4); }
+  #settingsTitle { font-size: 18px; font-weight: 700; margin-bottom: 12px; }
+  #settingsCard .srow { display: flex; gap: 12px; align-items: center; margin-bottom: 12px; }
+  #settingsCard .hint { font-size: 13px; color: var(--dim); }
+  .slabel { flex: 1; font-size: 18px; }
+  .stepBtn { width: 56px; height: 56px; border-radius: 12px; border: 1px solid var(--tile-bd);
+    background: var(--surf2); color: var(--fg); font-size: 28px; font-weight: 700; cursor: pointer; }
+  .stepBtn:active { background: var(--tile-bd); }
+  .stepVal { min-width: 92px; text-align: center; font-size: 20px; font-weight: 600; }
+  .pickRow { display: flex; align-items: center; gap: 12px; width: 100%; min-height: 60px; margin-bottom: 12px;
+    border-radius: 12px; border: 1px solid var(--tile-bd); background: var(--surf2); color: var(--fg);
+    cursor: pointer; padding: 8px 18px; font-family: inherit; }
+  .pickRow:active { background: var(--tile-bd); }
+  .pickName { font-size: 18px; font-weight: 600; flex: 0 0 auto; }
+  .pickVal { flex: 1; min-width: 0; text-align: right; font-size: 17px; color: var(--muted);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .pickChevron { flex: 0 0 auto; font-size: 22px; color: var(--dim); }
+  #settingsClose { min-height: 48px; min-width: 96px; border-radius: 10px; border: none;
+    background: var(--accent); color: var(--accent-fg, #04120b); font-size: 15px; font-weight: 700; cursor: pointer; }
+
+  /* Device picker overlay (microphone): full-height, one uniform row per device, ▲/▼ page buttons. */
+  #devOverlay { position: fixed; inset: 0; background: rgba(0,0,0,.55); display: flex;
+    align-items: center; justify-content: center; padding: 14px; z-index: 46; user-select: none; }
+  #devOverlay.hidden { display: none; }
+  #devCard { width: min(1200px, 100%); height: 100%; background: var(--surf); border: 1px solid var(--tile-bd);
+    border-radius: 16px; padding: 14px 20px; box-shadow: 0 12px 40px rgba(0,0,0,.4); display: flex; flex-direction: column; gap: 10px; }
+  #devTitleRow { display: flex; align-items: center; gap: 12px; flex: 0 0 auto; }
+  #devTitle { font-size: 20px; font-weight: 700; }
+  #devCancel { margin-left: auto; min-height: 56px; min-width: 140px; border-radius: 12px;
+    border: 1px solid var(--tile-bd); background: var(--surf2); color: var(--fg); font-size: 19px; font-weight: 600; cursor: pointer; }
+  #devListWrap { flex: 1; min-height: 0; display: flex; gap: 10px; }
+  #devList { flex: 1; min-width: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 12px;
+    touch-action: pan-y; overscroll-behavior: contain; scrollbar-width: none; }
+  #devList::-webkit-scrollbar { display: none; }
+  #devScrollBtns { flex: 0 0 56px; display: flex; flex-direction: column; gap: 10px; }
+  .projScrollBtn { flex: 1; min-height: 48px; border-radius: 12px; border: 1px solid var(--tile-bd);
+    background: var(--surf2); color: var(--fg); font-size: 26px; cursor: pointer; touch-action: none; }
+  .projScrollBtn:active { background: var(--tile-bd); }
+  .devRow { flex: 0 0 auto; min-height: 64px; border-radius: 12px; border: 1px solid var(--tile-bd);
+    background: var(--surf2); color: var(--fg); font-size: 26px; font-weight: 600; cursor: pointer;
+    text-align: left; padding: 8px 20px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .devRow:active { background: var(--tile-bd); }
+  .devRow.current { background: var(--accent); color: var(--accent-fg, #04120b); border-color: transparent; }
+</style>
+</head>
+<body>
+  <div id="wrap">
+    <div id="main">
+      <div id="card"><div id="empty">Not listening — tap the microphone to start live translation.</div><div id="list"></div></div>
+      <div id="statusRow"><div id="status">IDLE</div><div id="srcInfo"></div></div>
+    </div>
+    <div id="rail">
+      <div id="title">Live Translate</div>
+      <div id="target"><span class="arrow">translating to</span> <span class="lang" id="targetLang">English</span></div>
+      <button id="micBtn" class="iconBtn off" type="button" title="Tap to start/stop live translation">
+        <div id="micRipples"></div>
+        <svg class="glyph" viewBox="0 0 24 24"><rect x="9" y="2" width="6" height="12" rx="3"/><path d="M5 10v2a7 7 0 0 0 14 0v-2h-2v2a5 5 0 0 1-10 0v-2H5z"/><rect x="11" y="18.4" width="2" height="2.9"/><rect x="8" y="21.3" width="8" height="1.8" rx=".9"/></svg>
+        <svg class="ban" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10.6"/><line x1="4.6" y1="4.6" x2="19.4" y2="19.4"/></svg>
+      </button>
+      <div id="railBtns">
+        <button id="saveBtn" class="vpBtn" type="button">💾 Save to file <span class="sub" id="saveState">OFF</span></button>
+        <button id="settingsBtn" class="vpBtn" type="button">Settings</button>
+      </div>
+      <div id="srcPill"></div>
+    </div>
+  </div>
+  <div id="settingsOverlay" class="hidden">
+    <div id="settingsCard">
+      <div id="settingsTitle">Settings</div>
+      <button id="micPickBtn" class="pickRow" type="button">
+        <span class="pickName">Microphone</span><span id="micPickVal" class="pickVal"></span><span class="pickChevron">›</span>
+      </button>
+      <div class="srow"><span class="slabel">Voice pause tolerance</span>
+        <button id="pauseMinus" class="stepBtn" type="button">–</button>
+        <span id="pauseVal" class="stepVal"></span>
+        <button id="pausePlus" class="stepBtn" type="button">+</button></div>
+      <p class="hint" style="margin:0 0 12px">Pause tolerance = how long you can go quiet mid-sentence before the utterance is sent for translation.</p>
+      <div class="srow" style="justify-content:flex-end;margin:0"><button id="settingsClose" type="button">Done</button></div>
+    </div>
+  </div>
+  <div id="devOverlay" class="hidden">
+    <div id="devCard">
+      <div id="devTitleRow"><div id="devTitle">Microphone</div><button id="devCancel" type="button">Cancel</button></div>
+      <div id="devListWrap">
+        <div id="devList"></div>
+        <div id="devScrollBtns">
+          <button id="devScrollUp" class="projScrollBtn" type="button">▲</button>
+          <button id="devScrollDown" class="projScrollBtn" type="button">▼</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="claudevoice-vad.js"></script>
+  <script src="livetranslateview.js"></script>
+</body>
+</html>

--- a/app/livetranslateview.js
+++ b/app/livetranslateview.js
@@ -1,0 +1,203 @@
+function $(id) { return document.getElementById(id); }
+
+// One page = the livetranslate app. Options arrive as query params (musicview/claudevoiceview pattern);
+// none are secret, so there is no /app-config fetch. See docs -- Tier 1 live translation.
+var Q = new URLSearchParams(location.search);
+var BASE = '/' + (location.pathname.split('/')[1] || 'livetranslate');
+(function () {
+  document.body.classList.toggle('light', Q.get('_dark') === '0');
+  var a = Q.get('_accent') || '';
+  if (/^#[0-9a-fA-F]{6}$/.test(a)) document.documentElement.style.setProperty('--accent', a);
+  // Contrast-safe foreground for text on the accent (same luminance formula as the voice pages).
+  var hex = /^#[0-9a-fA-F]{6}$/.test(a) ? a : '#7CFFB2';
+  var r = parseInt(hex.slice(1, 3), 16) / 255, g = parseInt(hex.slice(3, 5), 16) / 255, b = parseInt(hex.slice(5, 7), 16) / 255;
+  var lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  document.documentElement.style.setProperty('--accent-fg', lum > 0.45 ? '#04120b' : '#f2f7fc');
+})();
+
+function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
+
+$('targetLang').textContent = Q.get('targetLangLabel') || 'English';
+
+// ---- captions ----
+// Finalized lines only (Wyoming STT here is utterance-final -- no interim tokens). The still-being-
+// transcribed utterance is a single "live" placeholder line whose blinking cursor signals activity.
+var MAX_LINES = 200;
+var lines = [];
+var livePending = false;
+function renderLines() {
+  var list = $('list');
+  $('empty').style.display = (lines.length || livePending) ? 'none' : '';
+  var html = lines.map(function (t, i) {
+    return '<div class="line' + (i >= lines.length - 2 ? ' recent' : '') + '">' + esc(t) + '</div>';
+  }).join('');
+  if (livePending) html += '<div class="line live"></div>';
+  list.innerHTML = html;
+  $('card').scrollTop = $('card').scrollHeight;
+}
+function showPending() { livePending = true; renderLines(); }
+function clearPending() { livePending = false; }
+function addLine(text) {
+  lines.push(text);
+  if (lines.length > MAX_LINES) lines = lines.slice(-MAX_LINES);
+  clearPending();
+  renderLines();
+}
+
+var RING_SIGNAL_STATES = { listening: 1 };
+function setStatus(status, errorText) {
+  var el = $('status');
+  el.textContent = (status || 'idle').toUpperCase();
+  el.className = status === 'listening' ? 'listening' : status === 'error' ? 'error' : '';
+  $('srcInfo').textContent = errorText || '';
+  console.log('OQX_RING::' + (RING_SIGNAL_STATES[status] ? status : 'idle'));   // drives the panel ring, like the voice pages
+}
+
+// ---- microphone devices (mic only -- no speaker/model here) ----
+// Persist the pick as a LABEL ('' = system default); Chromium salts deviceIds per origin and the
+// served port changes each launch, so the page re-matches label -> id at startup.
+var savedMicLabel = Q.get('micDevice') || '';
+var micDeviceId = '';
+var allDevices = [];
+var devicesReady = false;
+function matchDevices() {
+  var mic = allDevices.find(function (d) { return d.kind === 'audioinput' && d.label === savedMicLabel; });
+  micDeviceId = mic ? mic.deviceId : '';
+}
+function ensureDeviceIds(force) {
+  if (devicesReady && !force) return Promise.resolve();
+  return navigator.mediaDevices.getUserMedia({ audio: true }).then(function (tmp) {
+    return navigator.mediaDevices.enumerateDevices().then(function (devs) {
+      tmp.getTracks().forEach(function (t) { t.stop(); });
+      allDevices = devs || []; matchDevices(); devicesReady = true;
+    });
+  }).catch(function () { allDevices = []; matchDevices(); devicesReady = true; });
+}
+function syncMicPickVal() { $('micPickVal').textContent = savedMicLabel || 'System default'; }
+function renderDevOverlay() {
+  var el = $('devList'); el.innerHTML = '';
+  function addRow(label, value, current) {
+    var b = document.createElement('button');
+    b.type = 'button'; b.className = 'devRow' + (current ? ' current' : '');
+    b.textContent = label; b.title = label;
+    b.onclick = function () { pickMic(value); };
+    el.appendChild(b);
+  }
+  var devs = allDevices.filter(function (d) { return d.kind === 'audioinput' && d.label; });
+  var matched = !!savedMicLabel && devs.some(function (d) { return d.label === savedMicLabel; });
+  addRow('System default', '', !matched);
+  devs.forEach(function (d) { addRow(d.label, d.label, matched && d.label === savedMicLabel); });
+}
+function pickMic(label) {
+  $('devOverlay').classList.add('hidden');
+  savedMicLabel = label;
+  postOption('micDevice', label);
+  matchDevices();
+  syncMicPickVal();
+  if (listening && vad) {   // live: reopen the mic on the new device now
+    vad.stop();
+    vad.setInputDevice(micDeviceId);
+    vad.start(onSpeechStart, onSpeechEnd, onLevel).catch(function (e) { setStatus('error', 'Microphone switch failed: ' + (e && e.message ? e.message : e)); });
+  }
+}
+$('micPickBtn').onclick = function () {
+  $('devOverlay').classList.remove('hidden');
+  renderDevOverlay();
+  ensureDeviceIds(true).then(function () { renderDevOverlay(); });
+};
+$('devCancel').onclick = function () { $('devOverlay').classList.add('hidden'); };
+
+// ---- tap-to-toggle listening (VAD; not push-to-talk -- same model as the voice pages) ----
+var listening = false;
+var vadHangoverMs = parseInt(Q.get('vadHangoverMs'), 10) || 800;
+var vad = window.createClaudeVoiceVAD ? window.createClaudeVoiceVAD({ hangoverMs: vadHangoverMs }) : null;
+function onSpeechStart() { showPending(); setStatus('listening'); }
+function onSpeechEnd(pcm16) {
+  showPending();
+  fetch(BASE + '/audio', { method: 'POST', cache: 'no-store', body: pcm16.buffer })
+    .then(function (r) { return r.json(); })
+    .then(function (r) {
+      if (r && r.ok && r.text && r.text.trim()) addLine(r.text.trim());
+      else { clearPending(); renderLines(); setStatus(listening ? 'listening' : 'idle', r && r.error ? r.error : ''); }
+    })
+    .catch(function () { clearPending(); renderLines(); setStatus('error', 'Transcription request failed.'); });
+}
+var lastRippleAt = 0;
+function onLevel(level) {
+  if (!listening) return;
+  var now = Date.now();
+  if (level < 0.012 || now - lastRippleAt < 180) return;
+  lastRippleAt = now;
+  var r = document.createElement('div');
+  r.className = 'ripple';
+  $('micRipples').appendChild(r);
+  r.addEventListener('animationend', function () { r.remove(); });
+}
+function syncMicUI() { $('micBtn').classList.toggle('on', listening); $('micBtn').classList.toggle('off', !listening); }
+function toggleListening() {
+  if (!vad) { setStatus('error', 'Microphone engine failed to load.'); return; }
+  if (listening) {
+    listening = false; vad.stop(); clearPending(); renderLines(); setStatus('idle'); syncMicUI();
+  } else {
+    listening = true; setStatus('listening'); syncMicUI();
+    ensureDeviceIds().then(function () {
+      if (!listening) return;
+      vad.setInputDevice(micDeviceId);
+      return vad.start(onSpeechStart, onSpeechEnd, onLevel);
+    }).catch(function (e) {
+      listening = false; syncMicUI();
+      setStatus('error', 'Microphone access failed: ' + (e && e.message ? e.message : e));
+    });
+  }
+}
+$('micBtn').onclick = toggleListening;
+window.oqxToggleConversation = toggleListening;   // knob-tap hook, same as the voice pages
+
+// ---- save to file ----
+var saveOn = Q.get('saveToFile') === '1' || Q.get('saveToFile') === 'true';
+function syncSaveUI() { $('saveBtn').classList.toggle('on', saveOn); $('saveState').textContent = saveOn ? 'ON' : 'OFF'; }
+$('saveBtn').onclick = function () { saveOn = !saveOn; syncSaveUI(); postOption('saveToFile', saveOn ? '1' : '0'); };
+
+// ---- settings: pause tolerance ----
+function applyPause() {
+  vadHangoverMs = Math.max(400, Math.min(2500, vadHangoverMs));
+  if (vad && vad.setHangoverMs) vad.setHangoverMs(vadHangoverMs);
+  $('pauseVal').textContent = (vadHangoverMs / 1000).toFixed(1) + ' s';
+}
+$('pauseMinus').onclick = function () { vadHangoverMs -= 100; applyPause(); postOption('vadHangoverMs', vadHangoverMs); };
+$('pausePlus').onclick = function () { vadHangoverMs += 100; applyPause(); postOption('vadHangoverMs', vadHangoverMs); };
+$('settingsBtn').onclick = function () { syncMicPickVal(); $('settingsOverlay').classList.remove('hidden'); };
+$('settingsClose').onclick = function () { $('settingsOverlay').classList.add('hidden'); };
+
+// ▲/▼ page buttons for the device list (drag-thumbs proved unreliable on the panel -- see quake-touch-ui).
+function wireScrollButtons(listId, upId, downId) {
+  var list = $(listId);
+  function step(dir) { list.scrollBy({ top: dir * list.clientHeight * 0.9, behavior: 'smooth' }); }
+  [[upId, -1], [downId, 1]].forEach(function (pair) {
+    var btn = $(pair[0]); var repeat = null;
+    btn.addEventListener('pointerdown', function (e) { btn.setPointerCapture(e.pointerId); step(pair[1]); repeat = setInterval(function () { step(pair[1]); }, 400); });
+    ['pointerup', 'pointercancel'].forEach(function (ev) { btn.addEventListener(ev, function () { clearInterval(repeat); repeat = null; }); });
+  });
+}
+wireScrollButtons('devList', 'devScrollUp', 'devScrollDown');
+
+function postOption(key, value) {
+  fetch(BASE + '/option', {
+    method: 'POST', cache: 'no-store', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key: key, value: String(value) }),
+  }).catch(function () {});
+}
+
+// On-load snapshot: the real STT endpoint (for the source line) and the persisted save/target state.
+fetch(BASE + '/state', { cache: 'no-store' }).then(function (r) { return r.json(); })
+  .then(function (s) {
+    if (s.targetLangLabel) $('targetLang').textContent = s.targetLangLabel;
+    saveOn = !!s.saveToFile; syncSaveUI();
+    $('srcPill').textContent = s.sttConfigured ? ('STT ' + s.sttEndpoint) : 'STT not configured';
+    if (!s.sttConfigured) setStatus('idle', 'No STT endpoint set — use this page’s Advanced override, or Settings → TTS/STT.');
+  }).catch(function () {});
+
+applyPause();
+syncMicUI();
+syncSaveUI();
+renderLines();

--- a/app/main.js
+++ b/app/main.js
@@ -64,6 +64,7 @@ const { createCodexVoiceAdapter, findCodexExe } = require('./codexvoice-session'
 const { createCopilotVoiceAdapter, findCopilotExe } = require('./copilotvoice-session'); // GitHub Copilot CLI session adapter (ACP JSON-RPC over stdio)
 const { findClaudeExe } = require('./claudevoice-session'); // CLI presence probe for the editor's voice-app warning
 const { createOwuiVoiceAdapter } = require('./owuivoice-session'); // Open WebUI chat adapter (HTTP/SSE, no CLI)
+const { createLiveTranslateHost } = require('./livetranslate-host'); // Live Translate app host (Wyoming STT -> captions, no LLM)
 const owuiClient = require('./owuiClient'); // shared OWUI URL normalization + model-list probe
 const { resolveRunMode, reservedDisplayEnabled } = require('./runMode'); // pure run-mode helpers (panel/software/monitor)
 const voiceConfig = require('./voiceConfig'); // global TTS/STT endpoints + per-page override resolution + legacy migration
@@ -179,6 +180,14 @@ const owuiVoiceHost = createVoicePanelHost({
   },
   adapter: createOwuiVoiceAdapter({ resolveOwui: () => owuiSettings(), log: owuiVoiceLog }),
   deps: voicePanelDeps('owui-voice'),
+});
+// Live Translate (Tier 1): a captions page, NOT an agent -- a lightweight host with no LLM adapter,
+// just Wyoming STT -> text + optional file save. Reuses the voice-panel deps for STT endpoint
+// resolution (global settings.voice, or this page's Advanced override) and config persistence.
+const liveTranslateHost = createLiveTranslateHost({
+  appId: 'livetranslate',
+  log: message => console.log('[livetranslate] ' + message),
+  deps: voicePanelDeps('livetranslate'),
 });
 // Shared main.js plumbing for a voice-panel host. The ring guards are the two-app arbitration:
 // only the ON-SCREEN voice app may drive (or clear) the ring override -- a background app's
@@ -2462,6 +2471,12 @@ app.whenReady().then(async () => {
         'owui-voice': {
           htmlFile: 'claudevoiceview.html',
           handlers: owuiVoiceHost.handlers,
+        },
+        // Live Translate: a captions page, not an agent. Only transcribe/getState/setOption are
+        // implemented; no voiceToken and none of the LLM turn/SSE/speech routes are used.
+        'livetranslate': {
+          htmlFile: 'livetranslateview.html',
+          handlers: liveTranslateHost.handlers,
         },
       },
     });

--- a/app/sysserver.js
+++ b/app/sysserver.js
@@ -75,6 +75,7 @@ const STATIC_FILES = {
   '/schedule-app.js': 'application/javascript; charset=utf-8',
   '/keyshortcutsview.js': 'application/javascript; charset=utf-8',
   '/claudevoiceview.js': 'application/javascript; charset=utf-8',
+  '/livetranslateview.js': 'application/javascript; charset=utf-8',
   '/claudevoice-vad.js': 'application/javascript; charset=utf-8',
   '/recorderview.js': 'application/javascript; charset=utf-8',
   '/system-audio-capture.js': 'application/javascript; charset=utf-8',

--- a/apps/apps.json
+++ b/apps/apps.json
@@ -6341,5 +6341,17 @@
     "file": "lucidtypeview.html",
     "served": true,
     "options": []
+  },
+  {
+    "id": "livetranslate",
+    "name": "Live Translate",
+    "file": "livetranslateview.html",
+    "served": true,
+    "options": [
+      { "key": "targetLangLabel", "label": "Target language label (shown on the panel)", "type": "text", "default": "English" },
+      { "key": "saveToFile", "label": "Save transcript to a file (Documents\\OpenQuake Translations)", "type": "bool", "default": false },
+      { "key": "vadHangoverMs", "label": "Voice pause tolerance (ms)", "type": "text", "default": "800" },
+      { "key": "micDevice", "label": "Microphone (set from the panel Settings)", "type": "text", "default": "" }
+    ]
   }
 ]


### PR DESCRIPTION
Adds a **Live Translate** served panel app — live speech-to-captions on the 1920×480 panel, feeding a configurable Wyoming STT endpoint. The page is STT-endpoint-agnostic: point it at a normal endpoint for same-language captions, or at a translate-mode Whisper endpoint (see the companion tts-stt-windows PR) for live English.

## What's here
- `app/livetranslate-host.js` — lightweight host (no LLM adapter): mic PCM → Wyoming STT → text, with optional save-to-file (`Documents\OpenQuake Translations`).
- `app/livetranslateview.html` + `.js` — captions page, trimmed from the claude-voice view (same tokens, mic-toggle + ripple pattern, scroll card). Rail: target-language row, mic start/stop, Save-to-file toggle, Settings (mic picker + pause tolerance).
- Registered in `apps/apps.json`, `app/main.js` (require + host + voiceApps registry), `app/sysserver.js` (static asset), `app/config.js` (per-page STT-override gate).

## Usage
Add "Live Translate" to a page, set its **Advanced → Override TTS/STT** to the STT host/port, tap the mic. For live English, point it at the tts-stt-windows translate endpoint (default `127.0.0.1:10302`).

## Verification
- All 178 tests pass; JSON + JS syntax clean.
- Real page rendered at 1920×480: rail 284px, captions fill the left, overlays hidden, mic 116px, no console errors; captions render, Save toggle flips, Settings + mic picker work.

Part of the two-tier live-translation plan. UI follows `docs/design-system.md` + the `quake-touch-ui` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)