### PR TITLE
Live Translate via Soniox (real-time streaming translation)

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1696,20 +1696,32 @@
       </div>` + (canGrid ? `<div class="row" style="margin-top:10px"><label style="width:auto">Buttons</label>
         <label class="iconopt" style="width:auto; white-space:nowrap"><input type="checkbox" id="gGrid" ${g.gridOn ? 'checked' : ''}> Add a button grid beside the app</label></div>
       <p class="hint">Adds a strip of launcher tiles beside the app — pick the side, size, and tiles on the <b>Buttons</b> tab that appears.</p>` : '');
+    const xlProvider = optVal(g, 'provider', 'soniox');
     const liveTranslateBox = `<div style="margin-top:10px">
-        <p class="sectitle">Microphone</p>
+        <div class="row"><label>Provider</label>
+          <select id="xlProvider" style="flex:1">
+            <option value="soniox" ${xlProvider === 'soniox' ? 'selected' : ''}>Soniox — cloud real-time translation (recommended)</option>
+            <option value="wyoming" ${xlProvider === 'wyoming' ? 'selected' : ''}>Wyoming STT endpoint (legacy / self-hosted)</option>
+          </select></div>
+        ${xlProvider === 'soniox' ? `
+        <div class="row"><label>Soniox API key</label>${secretInput(optVal(g, 'sonioxApiKey', ''), 'id="xlSoniKey" style="flex:1"')}</div>
+        <p class="hint">From <b>soniox.com</b>. Stored encrypted; the panel uses a short-lived temp key so the real key never leaves this machine. ~$0.18/hr while actively translating.</p>
+        <div class="row" style="margin-top:10px"><label>Target language</label>
+          <input id="xlTargetLang" value="${esc(optVal(g, 'targetLanguage', 'en'))}" placeholder="en" style="width:120px"></div>
+        <div class="row"><label>Source hint</label>
+          <input id="xlSourceHint" value="${esc(optVal(g, 'sourceHint', ''))}" placeholder="blank = auto-detect (e.g. de)" style="width:230px"></div>
+        <p class="hint">Language codes (en, es, de, …). Source hint is optional — Soniox auto-detects otherwise.</p>` : `
+        <p class="hint">Wyoming: point this page's STT server at a <b>streaming</b> endpoint under <b>Advanced settings</b> below. (Utterance-final STT lags badly on continuous speech — Soniox is recommended for live use.)</p>`}
+        <p class="sectitle" style="margin-top:14px">Microphone</p>
         <div class="row"><label>Capture device</label>
           <select id="xlMic" style="flex:1"><option value="">System default</option></select></div>
         <p class="hint">The mic used for live translation (also selectable from the panel's Settings).</p>
-        <div class="row" style="margin-top:10px"><label>Target language</label>
-          <input id="xlLang" value="${esc(optVal(g, 'targetLangLabel', 'English'))}" style="flex:1"></div>
-        <p class="hint">Label shown on the panel. Tier 1 uses a translate-mode Whisper endpoint, which outputs English.</p>
         <div class="row" style="margin-top:10px"><label class="iconopt" style="width:auto"><input type="checkbox" id="xlSave" ${optVal(g, 'saveToFile', false) ? 'checked' : ''}> Save transcript to a file</label></div>
-        <p class="hint">Appends finalized lines to Documents\\OpenQuake Translations (toggle live from the panel too).</p>
+        <p class="hint">Appends to Documents\\OpenQuake Translations.</p>
+        ${xlProvider === 'wyoming' ? `
         <div class="row" style="margin-top:10px"><label style="width:auto">Voice pause tolerance</label>
           <input type="number" id="xlPause" min="400" max="2500" step="100" value="${esc(String(optVal(g, 'vadHangoverMs', 800)))}" style="width:110px">
-          <span class="hint" style="margin:0 0 0 8px">ms of silence before a phrase is translated</span></div>
-        <p class="hint">Point the STT server at a translate-mode endpoint: global <b>Settings → TTS/STT</b>, or override it for this page under <b>Advanced settings</b> below.</p>
+          <span class="hint" style="margin:0 0 0 8px">ms of silence before a phrase is sent</span></div>` : ''}
       </div>` + (canGrid ? `<div class="row" style="margin-top:10px"><label style="width:auto">Buttons</label>
         <label class="iconopt" style="width:auto; white-space:nowrap"><input type="checkbox" id="gGrid" ${g.gridOn ? 'checked' : ''}> Add a button grid beside the app</label></div>
       <p class="hint">Adds a strip of launcher tiles beside the app — pick the side, size, and tiles on the <b>Buttons</b> tab that appears.</p>` : '');
@@ -1895,7 +1907,13 @@
       document.getElementById('ltRewriteCustom').oninput = e => setOpt('rewriteCustomPrompt', e.target.value);
     } else if (isLiveTranslate) {
       const setOpt = (key, val) => { if (!g.options) g.options = {}; g.options[key] = val; markDirty(); };
-      // Microphone dropdown — the app's default capture device, same pattern as LucidType/Meeting.
+      document.getElementById('xlProvider').onchange = e => { setOpt('provider', e.target.value); render(); };   // re-render to swap provider-specific fields
+      const soniKey = document.getElementById('xlSoniKey'); if (soniKey) soniKey.onchange = e => setOpt('sonioxApiKey', e.target.value);
+      const tl = document.getElementById('xlTargetLang'); if (tl) tl.oninput = e => setOpt('targetLanguage', e.target.value.trim());
+      const sh = document.getElementById('xlSourceHint'); if (sh) sh.oninput = e => setOpt('sourceHint', e.target.value.trim());
+      const pause = document.getElementById('xlPause'); if (pause) pause.oninput = e => setOpt('vadHangoverMs', e.target.value);
+      document.getElementById('xlSave').onchange = e => setOpt('saveToFile', e.target.checked);
+      // Microphone dropdown — the app's default capture device (same pattern as LucidType/Meeting).
       // enumerateDevices exposes labels only after a getUserMedia grant, so grab-then-release once.
       (function () {
         const sel = document.getElementById('xlMic'); const cur = optVal(g, 'micDevice', '');
@@ -1914,9 +1932,6 @@
             .catch(() => fill(devs));
         }).catch(() => fill([]));
       })();
-      document.getElementById('xlLang').oninput = e => setOpt('targetLangLabel', e.target.value);
-      document.getElementById('xlSave').onchange = e => setOpt('saveToFile', e.target.checked);
-      document.getElementById('xlPause').oninput = e => setOpt('vadHangoverMs', e.target.value);
     } else if (isOffice) {
       wireOfficeOptions(g);
     } else {

--- a/app/livetranslate-host.js
+++ b/app/livetranslate-host.js
@@ -96,7 +96,7 @@ function createLiveTranslateHost({ appId = 'livetranslate', log, deps }) {
       }, res => {
         let data = ''; res.on('data', d => data += d); res.on('end', () => {
           let j = null; try { j = JSON.parse(data); } catch (e) {}
-          if (res.statusCode === 200 && j && j.api_key) resolve({ ok: true, apiKey: j.api_key, expiresAt: j.expires_at });
+          if (res.statusCode >= 200 && res.statusCode < 300 && j && j.api_key) resolve({ ok: true, apiKey: j.api_key, expiresAt: j.expires_at });
           else { say('Soniox token mint failed: ' + res.statusCode + ' ' + data.slice(0, 200)); resolve({ ok: false, error: (j && (j.error_message || j.message)) || ('Soniox HTTP ' + res.statusCode) }); }
         });
       });

--- a/app/livetranslate-host.js
+++ b/app/livetranslate-host.js
@@ -17,6 +17,7 @@
 //   activeGrid()   saveConfig()   getDocumentsPath()
 const fs = require('fs');
 const path = require('path');
+const https = require('https');                         // Soniox temporary-API-key mint
 const wyoming = require('./claudevoice-wyoming');       // pure Wyoming STT/TTS protocol client
 const { isSttNoisePhrase } = require('./voiceConfig');  // drops whisper's near-silence hallucinations
 
@@ -80,17 +81,48 @@ function createLiveTranslateHost({ appId = 'livetranslate', log, deps }) {
     }
   }
 
-  // Snapshot for the page's on-load /state fetch: whether an STT endpoint is set, its host:port (for
-  // the dim source line), the target-language label, and the current save state/path.
+  // Mint a SHORT-LIVED Soniox temporary API key from the page's stored key (plaintext in memory,
+  // encrypted at rest by secretStore). The renderer authenticates its Soniox WebSocket with this temp
+  // key, so the real key never leaves the main process.
+  function sonioxToken() {
+    const o = pageOptions();
+    const key = o && String(o.sonioxApiKey || '').trim();
+    if (!key) return Promise.resolve({ ok: false, error: 'Soniox API key not set (this page’s settings)' });
+    const body = JSON.stringify({ usage_type: 'transcribe_websocket', expires_in_seconds: 300, max_session_duration_seconds: 3600 });
+    return new Promise(resolve => {
+      const req = https.request('https://api.soniox.com/v1/auth/temporary-api-key', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer ' + key, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+      }, res => {
+        let data = ''; res.on('data', d => data += d); res.on('end', () => {
+          let j = null; try { j = JSON.parse(data); } catch (e) {}
+          if (res.statusCode === 200 && j && j.api_key) resolve({ ok: true, apiKey: j.api_key, expiresAt: j.expires_at });
+          else { say('Soniox token mint failed: ' + res.statusCode + ' ' + data.slice(0, 200)); resolve({ ok: false, error: (j && (j.error_message || j.message)) || ('Soniox HTTP ' + res.statusCode) }); }
+        });
+      });
+      req.on('error', e => { say('Soniox token error: ' + e.message); resolve({ ok: false, error: e.message }); });
+      req.write(body); req.end();
+    });
+  }
+
+  // Append finalized translation to the save file (the Soniox path posts the session text on stop).
+  function appendLine(text) { const t = String(text || '').trim(); if (t) maybeSave(t); return { ok: true }; }
+
+  // Snapshot for the page's on-load /state fetch: which provider, whether it's configured, target
+  // language, the Wyoming endpoint (legacy path), and the current save state.
   function getState() {
     const { sttHost, sttPort } = deps.voiceEndpoints();
     const o = pageOptions() || {};
+    const provider = o.provider || 'soniox';
     return {
       ok: true,
       status: 'idle',
+      provider,
+      sonioxConfigured: !!String(o.sonioxApiKey || '').trim(),
+      targetLanguage: o.targetLanguage || 'en',
       sttConfigured: !!(sttHost && sttPort),
       sttEndpoint: sttHost && sttPort ? (sttHost + ':' + sttPort) : '',
-      targetLangLabel: o.targetLangLabel || 'English',
+      targetLangLabel: o.targetLangLabel || '',
       saveToFile: truthy(o.saveToFile),
       savePath: currentSavePath || '',
     };
@@ -114,7 +146,7 @@ function createLiveTranslateHost({ appId = 'livetranslate', log, deps }) {
 
   return {
     appId,
-    handlers: { transcribe, getState, setOption },
+    handlers: { transcribe, getState, setOption, sonioxToken, appendLine },
     shutdown() {},   // nothing long-lived to tear down
   };
 }

--- a/app/livetranslateview.js
+++ b/app/livetranslateview.js
@@ -17,7 +17,11 @@ var BASE = '/' + (location.pathname.split('/')[1] || 'livetranslate');
 
 function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
 
-$('targetLang').textContent = Q.get('targetLangLabel') || 'English';
+// Provider: 'soniox' (cloud streaming translation, the good path) or 'wyoming' (legacy utterance STT).
+var provider = Q.get('provider') || 'soniox';
+var targetLanguage = (Q.get('targetLanguage') || 'en').trim();
+var sourceHint = (Q.get('sourceHint') || '').trim();
+$('targetLang').textContent = Q.get('targetLangLabel') || (provider === 'soniox' ? targetLanguage.toUpperCase() : 'English');
 
 // ---- captions ----
 // Finalized lines only (Wyoming STT here is utterance-final -- no interim tokens). The still-being-
@@ -25,13 +29,14 @@ $('targetLang').textContent = Q.get('targetLangLabel') || 'English';
 var MAX_LINES = 200;
 var lines = [];
 var livePending = false;
+var livePendingText = '';   // provisional (not-yet-final) tail shown on the live line (Soniox streaming)
 function renderLines() {
   var list = $('list');
   $('empty').style.display = (lines.length || livePending) ? 'none' : '';
   var html = lines.map(function (t, i) {
     return '<div class="line' + (i >= lines.length - 2 ? ' recent' : '') + '">' + esc(t) + '</div>';
   }).join('');
-  if (livePending) html += '<div class="line live"></div>';
+  if (livePending) html += '<div class="line live">' + esc(livePendingText) + '</div>';
   list.innerHTML = html;
   $('card').scrollTop = $('card').scrollHeight;
 }
@@ -94,11 +99,12 @@ function pickMic(label) {
   postOption('micDevice', label);
   matchDevices();
   syncMicPickVal();
-  if (listening && vad) {   // live: reopen the mic on the new device now
+  if (listening && provider !== 'soniox' && vad) {   // live (wyoming): reopen the mic on the new device now
     vad.stop();
     vad.setInputDevice(micDeviceId);
     vad.start(onSpeechStart, onSpeechEnd, onLevel).catch(function (e) { setStatus('error', 'Microphone switch failed: ' + (e && e.message ? e.message : e)); });
   }
+  // Soniox: the new device applies on the next start (avoids tearing a live cloud session).
 }
 $('micPickBtn').onclick = function () {
   $('devOverlay').classList.remove('hidden');
@@ -134,7 +140,97 @@ function onLevel(level) {
   r.addEventListener('animationend', function () { r.remove(); });
 }
 function syncMicUI() { $('micBtn').classList.toggle('on', listening); $('micBtn').classList.toggle('off', !listening); }
+
+// ---- Soniox real-time translation (streaming; the cloud provider) ----
+// Continuous mic PCM -> Soniox WebSocket -> live translated tokens. The real API key never reaches
+// this page: main mints a short-lived temporary key (GET /soniox-token) that we authenticate with.
+var soniWs = null, soniCtx = null, soniStream = null, soniProc = null;
+var soniFinal = '', soniProv = '';
+function renderSoniox() {
+  // Committed translation split into sentence-ish lines; the provisional tail is the blinking live line.
+  lines = (soniFinal.match(/[^.!?]+[.!?]*/g) || []).map(function (s) { return s.trim(); }).filter(Boolean);
+  if (lines.length > MAX_LINES) lines = lines.slice(-MAX_LINES);
+  livePending = true; livePendingText = soniProv.trim();
+  renderLines();
+}
+function toggleSoniox() {
+  if (listening) { stopSoniox(); return; }
+  listening = true; setStatus('listening'); syncMicUI();
+  fetch(BASE + '/soniox-token', { cache: 'no-store' }).then(function (r) { return r.json(); })
+    .then(function (t) {
+      if (!listening) return;   // toggled back off while the token was in flight
+      if (!t || !t.ok || !t.apiKey) throw new Error((t && t.error) || 'could not get a Soniox token');
+      return ensureDeviceIds().then(function () { if (listening) openSoniox(t.apiKey); });
+    })
+    .catch(function (e) { listening = false; syncMicUI(); setStatus('error', 'Soniox: ' + (e && e.message ? e.message : e)); });
+}
+function openSoniox(apiKey) {
+  soniFinal = ''; soniProv = ''; lines = []; renderLines();
+  soniWs = new WebSocket('wss://stt-rt.soniox.com/transcribe-websocket');
+  soniWs.binaryType = 'arraybuffer';
+  soniWs.onopen = function () {
+    var cfg = { api_key: apiKey, model: 'stt-rt-v5', audio_format: 's16le', sample_rate: 16000, num_channels: 1,
+      translation: { type: 'one_way', target_language: targetLanguage } };
+    if (sourceHint) cfg.language_hints = [sourceHint];
+    soniWs.send(JSON.stringify(cfg));
+    startSoniCapture();
+  };
+  soniWs.onmessage = function (ev) {
+    var msg; try { msg = JSON.parse(ev.data); } catch (e) { return; }
+    if (msg.error_code || msg.error_message) { setStatus('error', 'Soniox: ' + (msg.error_message || msg.error_code)); stopSoniox(); return; }
+    var prov = '';
+    (msg.tokens || []).forEach(function (tk) {
+      if (!tk.text || tk.translation_status !== 'translation') return;
+      if (tk.is_final) soniFinal += tk.text; else prov += tk.text;
+    });
+    soniProv = prov;
+    renderSoniox();
+    if (msg.finished) stopSoniox();
+  };
+  soniWs.onerror = function () { setStatus('error', 'Soniox connection error.'); };
+}
+function startSoniCapture() {
+  navigator.mediaDevices.getUserMedia({ audio: micDeviceId ? { deviceId: { ideal: micDeviceId } } : true }).then(function (stream) {
+    if (!listening) { stream.getTracks().forEach(function (t) { t.stop(); }); return; }
+    soniStream = stream;
+    soniCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 16000 });
+    var src = soniCtx.createMediaStreamSource(stream);
+    soniProc = soniCtx.createScriptProcessor(4096, 1, 1);
+    var mute = soniCtx.createGain(); mute.gain.value = 0;   // route to destination (some engines need it) but silent
+    src.connect(soniProc); soniProc.connect(mute); mute.connect(soniCtx.destination);
+    soniProc.onaudioprocess = function (e) {
+      if (!soniWs || soniWs.readyState !== 1) return;
+      var f = e.inputBuffer.getChannelData(0);
+      var pcm = new Int16Array(f.length);
+      var peak = 0;
+      for (var i = 0; i < f.length; i++) { var s = Math.max(-1, Math.min(1, f[i])); pcm[i] = s < 0 ? s * 0x8000 : s * 0x7fff; if (Math.abs(f[i]) > peak) peak = Math.abs(f[i]); }
+      try { soniWs.send(pcm.buffer); } catch (e2) {}
+      onLevel(peak);   // drive the mic-button ripples off the live input level
+    };
+  }).catch(function (e) {
+    setStatus('error', 'Microphone access failed: ' + (e && e.message ? e.message : e));
+    stopSoniox();
+  });
+}
+function stopSoniox() {
+  var wasListening = listening;
+  listening = false; syncMicUI();
+  try { if (soniProc) soniProc.disconnect(); } catch (e) {}
+  try { if (soniCtx) soniCtx.close(); } catch (e) {}
+  try { if (soniStream) soniStream.getTracks().forEach(function (t) { t.stop(); }); } catch (e) {}
+  soniProc = soniCtx = soniStream = null;
+  try { if (soniWs && soniWs.readyState === 1) soniWs.send(new ArrayBuffer(0)); } catch (e) {}   // empty frame = end of audio
+  try { if (soniWs) soniWs.close(); } catch (e) {}
+  soniWs = null;
+  if (wasListening && saveOn && soniFinal.trim()) {   // persist the whole session's translation on stop
+    postJson('/append-line', { text: soniFinal.trim() });
+  }
+  livePending = false; renderLines();
+  setStatus('idle');
+}
+
 function toggleListening() {
+  if (provider === 'soniox') { toggleSoniox(); return; }
   if (!vad) { setStatus('error', 'Microphone engine failed to load.'); return; }
   if (listening) {
     listening = false; vad.stop(); clearPending(); renderLines(); setStatus('idle'); syncMicUI();
@@ -181,20 +277,24 @@ function wireScrollButtons(listId, upId, downId) {
 }
 wireScrollButtons('devList', 'devScrollUp', 'devScrollDown');
 
-function postOption(key, value) {
-  fetch(BASE + '/option', {
-    method: 'POST', cache: 'no-store', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ key: key, value: String(value) }),
-  }).catch(function () {});
+function postOption(key, value) { postJson('/option', { key: key, value: String(value) }); }
+function postJson(path, body) {
+  fetch(BASE + path, { method: 'POST', cache: 'no-store', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).catch(function () {});
 }
 
 // On-load snapshot: the real STT endpoint (for the source line) and the persisted save/target state.
 fetch(BASE + '/state', { cache: 'no-store' }).then(function (r) { return r.json(); })
   .then(function (s) {
     if (s.targetLangLabel) $('targetLang').textContent = s.targetLangLabel;
+    else if (s.provider === 'soniox' && s.targetLanguage) $('targetLang').textContent = s.targetLanguage.toUpperCase();
     saveOn = !!s.saveToFile; syncSaveUI();
-    $('srcPill').textContent = s.sttConfigured ? ('STT ' + s.sttEndpoint) : 'STT not configured';
-    if (!s.sttConfigured) setStatus('idle', 'No STT endpoint set — use this page’s Advanced override, or Settings → TTS/STT.');
+    if (s.provider === 'soniox') {
+      $('srcPill').textContent = s.sonioxConfigured ? ('Soniox → ' + (s.targetLanguage || targetLanguage).toUpperCase()) : 'Soniox API key not set';
+      if (!s.sonioxConfigured) setStatus('idle', 'Add your Soniox API key in this page’s settings (config editor).');
+    } else {
+      $('srcPill').textContent = s.sttConfigured ? ('STT ' + s.sttEndpoint) : 'STT not configured';
+      if (!s.sttConfigured) setStatus('idle', 'No STT endpoint set — use this page’s Advanced override, or Settings → TTS/STT.');
+    }
   }).catch(function () {});
 
 applyPause();

--- a/app/sysserver.js
+++ b/app/sysserver.js
@@ -435,6 +435,7 @@ const VOICE_POST_SUFFIXES = new Set([
   '/model',
   '/tts',
   '/option',
+  '/append-line',
 ]);
 
 // TTS handoff: reply text can be many KB -- far beyond what fits in a GET query string (Node
@@ -575,6 +576,21 @@ async function handler(req, res) {
       const key = body && typeof body.key === 'string' ? body.key : '';
       if (!key || body.value == null || !h.setOption) return done(res, false);
       let ok = false; try { ok = !!h.setOption(key, String(body.value)); } catch (e) {}
+      return done(res, ok);
+    }
+    // Live Translate (Soniox provider): mint a short-lived temp key server-side so the real key never
+    // reaches the renderer; the page authenticates its Soniox WebSocket with it. GET, same-origin-gated.
+    if (voicePath === '/soniox-token') {
+      if (!h.sonioxToken) return json(res, { ok: false });
+      let out; try { out = await h.sonioxToken(); } catch (e) { out = { ok: false, error: e.message }; }
+      return json(res, out || { ok: false });
+    }
+    // Live Translate: persist the streamed translation to the save file (posted on stop).
+    if (voicePath === '/append-line' && req.method === 'POST') {
+      let body; try { body = await readJsonBody(req); } catch (e) { return done(res, false); }
+      const text = body && typeof body.text === 'string' ? body.text : '';
+      if (!text || !h.appendLine) return done(res, false);
+      let ok = false; try { ok = !!(h.appendLine(text) || {}).ok; } catch (e) {}
       return done(res, ok);
     }
     if (voicePath === '/tts' && req.method === 'POST') {

--- a/apps/apps.json
+++ b/apps/apps.json
@@ -6348,9 +6348,13 @@
     "file": "livetranslateview.html",
     "served": true,
     "options": [
-      { "key": "targetLangLabel", "label": "Target language label (shown on the panel)", "type": "text", "default": "English" },
+      { "key": "provider", "label": "Translation provider", "type": "select", "default": "soniox", "choices": [ ["soniox", "Soniox — cloud real-time translation (recommended)"], ["wyoming", "Wyoming STT endpoint (legacy / self-hosted)"] ] },
+      { "key": "sonioxApiKey", "label": "Soniox API key", "type": "secret", "default": "" },
+      { "key": "targetLanguage", "label": "Target language code (e.g. en, es, de)", "type": "text", "default": "en" },
+      { "key": "sourceHint", "label": "Source language hint (optional, e.g. de)", "type": "text", "default": "" },
+      { "key": "targetLangLabel", "label": "Panel label override (optional)", "type": "text", "default": "" },
       { "key": "saveToFile", "label": "Save transcript to a file (Documents\\OpenQuake Translations)", "type": "bool", "default": false },
-      { "key": "vadHangoverMs", "label": "Voice pause tolerance (ms)", "type": "text", "default": "800" },
+      { "key": "vadHangoverMs", "label": "Voice pause tolerance (ms, Wyoming provider only)", "type": "text", "default": "800" },
       { "key": "micDevice", "label": "Microphone (set from the panel Settings)", "type": "text", "default": "" }
     ]
   }

--- a/docs/soniox-translate-plan.md
+++ b/docs/soniox-translate-plan.md
@@ -1,0 +1,68 @@
+# Live Translate via Soniox (cloud provider) — verified integration plan
+
+Status: **plan + validation harness only.** No OQ renderer code written yet — deliberately gated on
+the harness proving Soniox's quality + latency on a real clip first (this session's hard lesson:
+never build the pipeline before proving the premise).
+
+## Why cloud / why Soniox
+Local CPU can't do live translation well (small streaming ASR + small MT compound errors; proven this
+session with whisper-tiny). Even DK-Suite (the commercial DECOKEE app) runs its translate through a
+cloud API. Soniox is a purpose-built **real-time speech→translated-text** WebSocket API, ~$0.18/hr,
+key-only config. It's the "for the masses" provider; the user's GPU WhisperLive container is the
+self-hosted provider behind the same OQ interface.
+
+## Verified Soniox protocol (from docs, 2026-08-19)
+- **WS URL:** `wss://stt-rt.soniox.com/transcribe-websocket`
+- **Config (first text frame):**
+  ```json
+  { "api_key": "<key or temp key>", "model": "stt-rt-v5",
+    "audio_format": "s16le", "sample_rate": 16000, "num_channels": 1,
+    "language_hints": ["de"],
+    "translation": { "type": "one_way", "target_language": "en" } }
+  ```
+- **Audio:** raw binary PCM frames (16-bit LE, 16 kHz, mono) after the config. Soniox does its own
+  endpointing — stream continuously, no client-side VAD segmentation.
+- **Responses (text frames):** `{ "tokens": [ { "text", "is_final", "translation_status":
+  "original"|"translation", "start_ms", "end_ms", "confidence" } ] }`. Render the tokens where
+  `translation_status === "translation"`; `is_final:false` = provisional (replace), `true` = committed.
+- **End:** send an empty frame → server sends `{ "finished": true }` → closes.
+- **Temp key (keeps the real key out of the browser):**
+  `POST https://api.soniox.com/v1/auth/temporary-api-key`
+  headers `Authorization: Bearer <real key>`, `Content-Type: application/json`
+  body `{ "usage_type": "transcribe_websocket", "expires_in_seconds": 300, "max_session_duration_seconds": 3600 }`
+  → `{ "api_key": "<temp key>", "expires_at": "…" }`.
+
+## Validation harness (built — `tools/soniox-test.js`)
+Streams a 16 kHz mono WAV to Soniox with one-way translation, paced in real-time 100 ms chunks, prints
+live target-language captions + latency. Run on SchmitzMegaplex (reuses the `german.wav` already there):
+```bash
+docker run --rm -e SONIOX_API_KEY=YOURKEY -v "$PWD":/data -w /data node:20-slim \
+  sh -c "npm i ws >/dev/null 2>&1 && node soniox-test.js german.wav en de"
+```
+Judge: is German→English correct on common words, and do captions appear within ~1–2 s? That decides go/no-go.
+
+## OQ integration (to build once the harness passes)
+Provider abstraction on the existing Live Translate app. Key handling stays server-side via temp keys.
+
+1. **Config** (`apps/apps.json` livetranslate options + `app/config.js` box): `provider`
+   (`wyoming` | `soniox`), `sonioxApiKey` (**secret** → `secretStore.js`, never sent to the renderer),
+   `targetLanguage` (default `en`), `sourceHint` (optional). Keep `micDevice` etc.
+2. **Main** (`app/livetranslate-host.js`): add `sonioxToken()` — POST the temp-key endpoint with the
+   real key from `secretStore`, return `{ api_key, expires_at }`. Wire a `/livetranslate/soniox-token`
+   route in `sysserver.js`'s voice dispatch (small addition next to `/state`/`/option`).
+3. **Page** (`app/livetranslateview.js`): add a **streaming** mode for `provider==='soniox'`:
+   - On start: `GET /livetranslate/soniox-token` → temp key.
+   - Open `wss://stt-rt.soniox.com/transcribe-websocket`; send the config (with `translation`).
+   - Capture **continuous** mic PCM at 16 kHz mono s16le (getUserMedia + AudioWorklet/ScriptProcessor —
+     NOT the VAD utterance path) and send as binary frames.
+   - Render `translation_status==='translation'` tokens live into the existing captions view
+     (provisional tail + committed lines). Reuse the current caption DOM.
+   - On stop: send empty frame, close WS.
+4. **The WhisperLive/local provider** later uses the same streaming page path pointed at the local WS
+   (its own protocol/adapter) — one interface, two backends; Google deferred.
+
+## Notes / decisions
+- Reuses the existing Live Translate page shell (captions view, rail, mic toggle, settings).
+- The Wyoming/utterance path is effectively dead for live use; the streaming path replaces it.
+- On-demand GPU (start/stop the WhisperLive container from OQ) is a separate, already-scoped piece
+  (mirrors the meeting diarizer's pre/post hooks) and only applies to the local provider.

--- a/tools/soniox-test.js
+++ b/tools/soniox-test.js
@@ -1,0 +1,106 @@
+'use strict';
+// Soniox real-time speech-translation VALIDATION HARNESS.
+// Streams a 16 kHz mono 16-bit WAV to Soniox's real-time WebSocket API with one-way translation,
+// paced in ~100 ms chunks so latency reflects live mic use, and prints the live translated captions
+// plus latency numbers. Proves quality + latency before any OQ integration.
+//
+// Run (needs only your Soniox API key + a 16 kHz mono WAV):
+//   SONIOX_API_KEY=xxxxx node soniox-test.js german.wav en de
+//   arg1 = WAV path (default german.wav)   arg2 = target lang (default en)   arg3 = source hint (optional)
+const fs = require('fs');
+const WebSocket = require('ws');
+
+const API_KEY = process.env.SONIOX_API_KEY;
+if (!API_KEY) { console.error('Set SONIOX_API_KEY=<your key>'); process.exit(1); }
+const wavPath = process.argv[2] || 'german.wav';
+const target = process.argv[3] || 'en';
+const sourceHint = process.argv[4] || null;
+
+// Minimal WAV reader — expects PCM 16-bit. Returns { sampleRate, channels, bits, pcm }.
+function readWav(p) {
+  const b = fs.readFileSync(p);
+  if (b.toString('ascii', 0, 4) !== 'RIFF' || b.toString('ascii', 8, 12) !== 'WAVE') throw new Error('not a WAV file');
+  let off = 12, fmt = null, dataOff = -1, dataLen = 0;
+  while (off + 8 <= b.length) {
+    const id = b.toString('ascii', off, off + 4);
+    const sz = b.readUInt32LE(off + 4);
+    if (id === 'fmt ') fmt = { channels: b.readUInt16LE(off + 10), sampleRate: b.readUInt32LE(off + 12), bits: b.readUInt16LE(off + 22) };
+    else if (id === 'data') { dataOff = off + 8; dataLen = sz; }
+    off += 8 + sz + (sz & 1);
+  }
+  if (!fmt || dataOff < 0) throw new Error('missing fmt/data chunk');
+  return { sampleRate: fmt.sampleRate, channels: fmt.channels, bits: fmt.bits, pcm: b.subarray(dataOff, dataOff + dataLen) };
+}
+
+let wav;
+try { wav = readWav(wavPath); } catch (e) { console.error('WAV error:', e.message); process.exit(1); }
+if (wav.bits !== 16 || wav.channels !== 1) {
+  console.error(`Expected 16-bit mono WAV; got ${wav.bits}-bit ${wav.channels}ch.`);
+  console.error('Convert with:  ffmpeg -i input.mp3 -ar 16000 -ac 1 german.wav');
+  process.exit(1);
+}
+console.log(`WAV: ${wav.sampleRate} Hz mono, ${(wav.pcm.length / 2 / wav.sampleRate).toFixed(1)}s  →  translating to "${target}"${sourceHint ? ` (source hint: ${sourceHint})` : ''}\n`);
+
+const ws = new WebSocket('wss://stt-rt.soniox.com/transcribe-websocket');
+let startMs = 0, firstTokenMs = 0, firstTransMs = 0;
+let finalOriginal = '', finalTranslation = '';
+let doneCalled = false;
+
+ws.on('open', () => {
+  const cfg = {
+    api_key: API_KEY,
+    model: 'stt-rt-v5',
+    audio_format: 's16le',
+    sample_rate: wav.sampleRate,
+    num_channels: 1,
+    translation: { type: 'one_way', target_language: target },
+  };
+  if (sourceHint) cfg.language_hints = [sourceHint];
+  ws.send(JSON.stringify(cfg));
+  startMs = Date.now();
+
+  // Pace the PCM at real-time (100 ms of audio every 100 ms) so latency is representative of a live mic.
+  const bytesPer100ms = Math.floor(wav.sampleRate * 2 * 0.1);   // 16-bit mono
+  let pos = 0;
+  const timer = setInterval(() => {
+    if (pos >= wav.pcm.length) {
+      clearInterval(timer);
+      try { ws.send(Buffer.alloc(0)); } catch (e) {}   // empty frame signals end-of-audio
+      return;
+    }
+    ws.send(wav.pcm.subarray(pos, Math.min(pos + bytesPer100ms, wav.pcm.length)));
+    pos += bytesPer100ms;
+  }, 100);
+});
+
+ws.on('message', (data) => {
+  let msg; try { msg = JSON.parse(data.toString()); } catch (e) { return; }
+  if (msg.error_code || msg.error_message) { console.error('\nSoniox error:', msg.error_code, msg.error_message); process.exit(1); }
+  let provisional = '';
+  for (const t of (msg.tokens || [])) {
+    if (!t.text) continue;
+    if (!firstTokenMs) firstTokenMs = Date.now();
+    if (t.translation_status === 'translation') {
+      if (!firstTransMs) firstTransMs = Date.now();
+      if (t.is_final) finalTranslation += t.text; else provisional += t.text;
+    } else if (t.is_final) {
+      finalOriginal += t.text;
+    }
+  }
+  const live = (finalTranslation + provisional).replace(/\s+/g, ' ').trim();
+  process.stdout.write('\r\x1b[2K' + target.toUpperCase() + '> ' + live.slice(-170));
+  if (msg.finished) done();
+});
+ws.on('close', () => done());
+ws.on('error', (e) => { console.error('\nWS error:', e.message); process.exit(1); });
+
+function done() {
+  if (doneCalled) return; doneCalled = true;
+  console.log('\n\n=== RESULT ===');
+  console.log('Original     :', finalOriginal.replace(/\s+/g, ' ').trim());
+  console.log('Translation  :', finalTranslation.replace(/\s+/g, ' ').trim());
+  console.log('First word   :', firstTokenMs ? (firstTokenMs - startMs) + ' ms after start' : 'n/a');
+  console.log('First translated word:', firstTransMs ? (firstTransMs - startMs) + ' ms after start' : 'n/a');
+  console.log('\nJudge: is the translation correct on common words, and did captions appear within ~1–2 s?');
+  process.exit(0);
+}


### PR DESCRIPTION
Live translation that actually works on the panel — streaming, low-latency, good quality. Replaces the abandoned whisper-translate approach (utterance-final STT lagged badly on continuous speech; local-CPU translation quality was poor).

## What it does
The Live Translate app gains a **provider abstraction** (default **Soniox**, cloud real-time speech→translated-text; legacy Wyoming kept as a fallback). The panel page streams continuous 16 kHz mono PCM to Soniox over WebSocket and renders the translated tokens live.

- **Key security**: the real Soniox key never reaches the renderer. Main mints a short-lived temp key (`/soniox-token` → Soniox `POST /v1/auth/temporary-api-key`); the page authenticates its WS with that.
- **Config**: provider selector, Soniox API key (encrypted at rest via secretStore), target language, optional source hint — in the editor box.
- Save-to-file supported (writes the session's translation on stop).
- ~$0.18/hr while actively translating; nothing when idle.

## Files
- `app/livetranslateview.js` — Soniox streaming path (continuous capture + WS + token rendering).
- `app/livetranslate-host.js` — `sonioxToken()` temp-key mint (+ `appendLine` save), provider-aware `/state`.
- `app/sysserver.js` — `/soniox-token` (GET) + `/append-line` (POST) routes.
- `apps/apps.json`, `app/config.js` — provider/key/language options + editor box.
- `tools/soniox-test.js`, `docs/soniox-translate-plan.md` — the validation harness + verified protocol/plan.

## Verification
- 178 tests pass; page loads with no console errors; provider state renders.
- Protocol proven standalone via `tools/soniox-test.js` (German→English, live).
- **Confirmed working end-to-end on the real panel** — live captions, quality on par with YouTube auto-translate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)