### PR TITLE
Live Translate: global toggle-translation hotkey

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1730,6 +1730,10 @@
         <div class="row"><label>Capture device</label>
           <select id="xlMic" style="flex:1"><option value="">System default</option></select></div>
         <p class="hint">The mic used for live translation (also selectable from the panel's Settings).</p>
+        <div class="row" style="margin-top:10px"><label>Toggle hotkey</label>
+          <input id="xlHotkey" readonly placeholder="click, then press keys" value="${esc(optVal(g, 'micHotkey', ''))}" style="width:220px">
+          <button id="xlHotkeyClear" type="button" style="margin-left:8px">Clear</button></div>
+        <p class="hint">A global key combo (needs a modifier) that starts/stops translation from any app — it switches to this page and toggles the mic. Applies on Save.</p>
         <div class="row" style="margin-top:10px"><label class="iconopt" style="width:auto"><input type="checkbox" id="xlSave" ${optVal(g, 'saveToFile', false) ? 'checked' : ''}> Save transcript to a file</label></div>
         <div class="row"><label>Save folder</label>
           <input id="xlSaveFolder" value="${esc(optVal(g, 'saveFolder', ''))}" placeholder="Documents\\OpenQuake Translations" readonly style="flex:1">
@@ -1936,6 +1940,7 @@
       const xlWlToken = document.getElementById('xlWlToken'); if (xlWlToken) xlWlToken.onchange = e => setOpt('whisperToken', e.target.value);
       const xlWlStart = document.getElementById('xlWlStart'); if (xlWlStart) xlWlStart.oninput = e => setOpt('whisperStartCmd', e.target.value);
       const xlWlStop = document.getElementById('xlWlStop'); if (xlWlStop) xlWlStop.oninput = e => setOpt('whisperStopCmd', e.target.value);
+      const xlHotkey = document.getElementById('xlHotkey'); if (xlHotkey) { xlHotkey.onkeydown = e => { e.preventDefault(); const acc = accelFromEvent(e); if (acc) { xlHotkey.value = acc; setOpt('micHotkey', acc); } }; document.getElementById('xlHotkeyClear').onclick = () => { xlHotkey.value = ''; setOpt('micHotkey', ''); }; }
       // Microphone dropdown — the app's default capture device (same pattern as LucidType/Meeting).
       // enumerateDevices exposes labels only after a getUserMedia grant, so grab-then-release once.
       (function () {

--- a/app/index.js
+++ b/app/index.js
@@ -14,6 +14,7 @@
   let knobSel = -1;   // knob "select button" mode: index of the highlighted tile (-1 = none)
   let pendingRotFlash = false;   // a knob click just toggled rotation -> flash the new state when it comes back
   let webMode = false, curUrl = '', webReady = false, webDown = false, lastWeb = { x: 0, y: 0 }, webIdle = null;
+  let pendingMicToggle = false;   // a translation-toggle hotkey fired while the page was still loading; run on dom-ready
   let haToken = '', haInject = false, webExternalLinks = false, webAttached = false, pendingWebUrl = null;
   let webThemed = false, lastTheme = null;   // our served app pages (Music/Chat): inject live light/dark + accent into the guest
   // dashboard button strip: webRegion = the webview's sub-rect, webStrip = the tile-strip geometry (null = none)
@@ -34,6 +35,7 @@
   }
   web.addEventListener('dom-ready', () => {
     webReady = true;
+    if (pendingMicToggle) { pendingMicToggle = false; web.executeJavaScript('window.oqxToggleConversation && window.oqxToggleConversation()').catch(function () {}); }
     if (!webAttached) {
       webAttached = true;
       try { defaultUA = web.getUserAgent(); } catch (e) {}      // true default (about:blank), before any override
@@ -407,6 +409,15 @@
       else if (e.key === 'Enter') { e.preventDefault(); confirmSelector(); }
     });
   }
+
+  // ---- translation-toggle hotkey ----
+  // A global hotkey (registered in main) sends 'micToggle'; run the served page's own mic toggle --
+  // the exact hook the knob uses (window.oqxToggleConversation). If main just switched to the page
+  // and the webview isn't ready yet, defer until dom-ready fires.
+  panelApi.onMicToggle(() => {
+    if (webMode && webReady) web.executeJavaScript('window.oqxToggleConversation && window.oqxToggleConversation()').catch(function () {});
+    else pendingMicToggle = true;
+  });
 
   // ---- knob ----
   // The knob does click-type detection in hardware: press index 1 = single-click, 2 = double-click.

--- a/app/main.js
+++ b/app/main.js
@@ -2099,6 +2099,20 @@ function applyShortcuts() {
       if (!ok) console.log('shortcut already in use, not registered:', g.shortcut, '->', g.id);
     } catch (e) { console.log('shortcut register error:', g.shortcut, '-', e.message); }
   }
+  // Live Translate: a per-page hotkey that toggles translation (start/stop listening). Global, so it
+  // fires from any app; if the page isn't on-screen it is switched to first, then the mic toggles.
+  for (const g of (config.grids || [])) {
+    if (!(g.kind === 'app' && g.app === 'livetranslate' && g.options && g.options.micHotkey)) continue;
+    try {
+      const ok = globalShortcut.register(g.options.micHotkey, () => {
+        if (process.platform === 'win32') modifiersInAccelerator(g.options.micHotkey).forEach(m => mediaKeys.keyUp(m));
+        const active = activeGrid();
+        if (!(active && active.id === g.id)) gotoGrid(g.id, true);   // bring the page on-screen (loads it)
+        if (panelWin && !panelWin.isDestroyed()) panelWin.webContents.send('micToggle');
+      });
+      if (!ok) console.log('shortcut already in use, not registered:', g.options.micHotkey, '-> livetranslate toggle', g.id);
+    } catch (e) { console.log('shortcut register error:', g.options.micHotkey, '-', e.message); }
+  }
   // Rotation toggle hotkey: same start/stop path as the knob, tray, and panel, so all three stay in sync.
   // Only registered while auto-rotate is enabled — matches the tray item (which hides when it's off) and
   // avoids holding a global combo hostage for a feature that can't run. Page hotkeys register first, so a

--- a/app/panel-preload.js
+++ b/app/panel-preload.js
@@ -29,5 +29,6 @@ contextBridge.exposeInMainWorld('openQuakePanel', {
   onIntro(callback) { return on('intro', callback); },
   onTouch(callback) { return on('touch', callback); },
   onKnob(callback) { return on('knob', callback); },
+  onMicToggle(callback) { return on('micToggle', callback); },
   onReloadDashboard(callback) { return on('reloadDashboard', callback); },
 });

--- a/apps/apps.json
+++ b/apps/apps.json
@@ -6360,7 +6360,8 @@
       { "key": "saveToFile", "label": "Save transcript to a file", "type": "bool", "default": false },
       { "key": "saveFolder", "label": "Save folder (blank = Documents\\OpenQuake Translations)", "type": "text", "default": "" },
       { "key": "vadHangoverMs", "label": "Voice pause tolerance (ms, Wyoming provider only)", "type": "text", "default": "800" },
-      { "key": "micDevice", "label": "Microphone (set from the panel Settings)", "type": "text", "default": "" }
+      { "key": "micDevice", "label": "Microphone (set from the panel Settings)", "type": "text", "default": "" },
+      { "key": "micHotkey", "label": "Toggle-translation hotkey (global)", "type": "text", "default": "" }
     ]
   }
 ]


### PR DESCRIPTION
A per-page **hotkey to start/stop translation** from anywhere (as requested alongside the WhisperLive provider).

- Set a combo in the Live Translate editor (`micHotkey`, captured like LucidType's hotkeys).
- Registered globally in `applyShortcuts`. Pressing it switches to the Live Translate page if it isn't on-screen, then toggles the mic — via the exact `window.oqxToggleConversation` hook the knob already uses.
- New `micToggle` IPC + `panel-preload` bridge; `index.js` defers the toggle to `dom-ready` when the page was just switched in.

Verified: 178 tests pass; all five touched files syntax-clean. (Runtime toggling needs a running panel to exercise, like the knob path it mirrors.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)