### PR TITLE
Live Translate: request large-v3 for WhisperLive

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1714,6 +1714,8 @@
         <div class="row"><label>WhisperLive URL</label>
           <input id="xlWlUrl" value="${esc(optVal(g, 'whisperUrl', ''))}" placeholder="ws://192.168.1.25:19000" style="flex:1"></div>
         <div class="row"><label>Token (optional)</label>${secretInput(optVal(g, 'whisperToken', ''), 'id="xlWlToken" style="flex:1"')}</div>
+        <div class="row"><label>Whisper model</label>
+          <input id="xlWlModel" value="${esc(optVal(g, 'whisperModel', 'large-v3'))}" placeholder="large-v3" style="width:180px"></div>
         <div class="row" style="margin-top:10px"><label>Target language</label>
           <input id="xlTargetLang" value="${esc(optVal(g, 'targetLanguage', 'en'))}" placeholder="en" style="width:120px"></div>
         <div class="row"><label>Source hint</label>
@@ -1936,6 +1938,7 @@
       const xlWlToken = document.getElementById('xlWlToken'); if (xlWlToken) xlWlToken.onchange = e => setOpt('whisperToken', e.target.value);
       const xlWlStart = document.getElementById('xlWlStart'); if (xlWlStart) xlWlStart.oninput = e => setOpt('whisperStartCmd', e.target.value);
       const xlWlStop = document.getElementById('xlWlStop'); if (xlWlStop) xlWlStop.oninput = e => setOpt('whisperStopCmd', e.target.value);
+      const xlWlModel = document.getElementById('xlWlModel'); if (xlWlModel) xlWlModel.oninput = e => setOpt('whisperModel', e.target.value.trim());
       // Microphone dropdown — the app's default capture device (same pattern as LucidType/Meeting).
       // enumerateDevices exposes labels only after a getUserMedia grant, so grab-then-release once.
       (function () {

--- a/app/livetranslateview.js
+++ b/app/livetranslateview.js
@@ -21,6 +21,7 @@ function esc(s) { var d = document.createElement('div'); d.textContent = s == nu
 var provider = Q.get('provider') || 'soniox';
 var targetLanguage = (Q.get('targetLanguage') || 'en').trim();
 var sourceHint = (Q.get('sourceHint') || '').trim();
+var whisperModel = (Q.get('whisperModel') || 'large-v3').trim();   // WhisperLive: model requested per connection
 $('targetLang').textContent = Q.get('targetLangLabel') || (provider === 'wyoming' ? 'English' : targetLanguage.toUpperCase());
 
 // ---- captions ----
@@ -257,7 +258,7 @@ function openWhisper(url, token) {
   try { wlWs = new WebSocket(full); } catch (e) { listening = false; syncMicUI(); setStatus('error', 'WhisperLive: bad URL'); return; }
   wlWs.binaryType = 'arraybuffer';
   wlWs.onopen = function () {
-    wlWs.send(JSON.stringify({ uid: wlUid, language: sourceHint || null, task: 'transcribe', use_vad: true,
+    wlWs.send(JSON.stringify({ uid: wlUid, language: sourceHint || null, task: 'transcribe', model: whisperModel, use_vad: true,
       send_last_n_segments: 10, enable_translation: true, target_language: targetLanguage }));
   };
   wlWs.onmessage = function (ev) {

--- a/apps/apps.json
+++ b/apps/apps.json
@@ -6354,6 +6354,7 @@
       { "key": "sourceHint", "label": "Source language hint (optional, e.g. de)", "type": "text", "default": "" },
       { "key": "whisperUrl", "label": "WhisperLive WebSocket URL (e.g. ws://192.168.1.25:19000)", "type": "text", "default": "" },
       { "key": "whisperToken", "label": "WhisperLive token (optional)", "type": "secret", "default": "" },
+      { "key": "whisperModel", "label": "WhisperLive model (large-v3 recommended)", "type": "text", "default": "large-v3" },
       { "key": "whisperStartCmd", "label": "WhisperLive start command (optional)", "type": "text", "default": "" },
       { "key": "whisperStopCmd", "label": "WhisperLive stop command (optional)", "type": "text", "default": "" },
       { "key": "targetLangLabel", "label": "Panel label override (optional)", "type": "text", "default": "" },


### PR DESCRIPTION
Sends an explicit `model` in the WhisperLive config so the GPU server uses **large-v3** (excellent transcription) instead of falling back to its default. New `whisperModel` option (default large-v3), editable in the WhisperLive section of the editor. Pairs with the openquake-translate container. 178 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)