### PR TITLE
docs: DK-Suite feature-parity tracker

### DIFF
--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -34,13 +34,13 @@ don't — update it when either side changes.
 | Feature | Status |
 |---|---|
 | **AI prompt profiles** (the real feature inside their "Smart Profiles": named system-prompt modes in AI chat — theirs: 6, Chinese-only) | Approved and in progress on branch `smart-profiles`: a global library of 9 editable English profiles applying to **all five AI Voice backends**, switchable from the panel / by knob twist / per page, plus next/previous-page tile actions (their `nextProfile` parity). Rides on the AI Voice consolidation (branch `ai-voice`), which also adds the any-OpenAI-compatible-API chat backend. |
+| **Screensaver page — wallpapers incl. AI-generated** (teardown: their wallpaper feature, the "Vivid" profile, is a manual crossfading image/video page — no idle detection) | In progress on branch `screensaver`: a media slideshow page (drop images/videos in a folder — your own ComfyUI/AI renders go straight in, no credits) plus built-in animated scenes (color waves, starfield, code rain, big clock), and it **auto-starts when the panel sits idle and wakes back to where you were** — which theirs can't do. |
 
 ## ❌ Missing (the actual todo)
 
 | Feature | What they advertise | Lift for open-quake |
 |---|---|---|
 | **macOS / Linux support** | Multi-OS: Windows, macOS, Linux | **Large.** The launcher/editor are Electron (portable), but launch/volume/media/loopback-audio/reserved-display code is Windows-specific (README already flags this). Realistic only as a scoped "panel + apps, minus Windows-only extras" port. |
-| **AI-generated wallpapers** | "Wallpaper Generation by AI" + random wallpaper rotation | **Medium.** OQ has no wallpaper concept — pages are functional. Would be a new "ambient page" type + an image-gen backend (user's own key, same BYO pattern). Questionable value; the panel is usually showing something useful. |
 | **AI-generated shortcut panels** | Hold the knob and say e.g. "create a shortcut set for Photoshop masking" — the AI generates a custom control set for that application, no manual macro programming (Kickstarter/copilot pages) | **Medium — and a natural fit.** OQ already has the two halves: AI routing (CLI agents / OWUI / any endpoint, no credits) and pages-as-JSON tile grids with `key`-type shortcut tiles. The missing piece is a "Generate panel with AI" flow in the editor (and/or by voice on the panel): prompt → validated tile JSON → new page for review. Probably the highest-value item on this list. |
 | **Game voice control** | Mentioned in their showcase | **Unclear scope.** Nearest OQ equivalents: global hotkeys, macros, LucidType. Needs a real definition of what theirs does before it's worth chasing. |
 

--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -3,7 +3,8 @@
 What the commercial package advertises versus what open-quake ships. Comparison sources: the
 [DECOKEE Quake product page](https://www.decokee.com/products/decokee-quake-desktop-ai-assistant)
 plus their [Kickstarter](https://www.kickstarter.com/projects/decokee/decokee-quake-the-ultimate-desktop-ai-copilot)
-and [AI-copilot](https://www.decokee.com/pages/quake-ai-copilot) pages (as advertised 2026-08); the
+and [AI-copilot](https://www.decokee.com/pages/quake-ai-copilot) pages (as advertised 2026-08),
+cross-checked against a teardown of the installed DK-Suite (v0.4.69, unpacked Electron); the
 open-quake side is current `main` (v0.5.7). This is the running list of what they have that we
 don't — update it when either side changes.
 
@@ -26,6 +27,13 @@ don't — update it when either side changes.
 | LED ring status for recording/translation/AI states | RGB ring is theme-driven and state-driven (listening/thinking/speaking/approval), fully configurable. |
 | Knob + touchscreen + gestures | Full knob support (rotate/click/double/hold), touch, page selector. |
 | Credit packs / subscriptions | Nothing metered. Costs are only what your own keys/servers cost. |
+| 9 Smart Profiles (knob-switchable "modes") | Teardown: their 9 "profiles" are **page layouts** (Discord/MeetAI/SysView/AI Chat/Music/Clock/…) — already open-quake **pages** with the knob selector and per-page hotkeys. The genuinely new piece inside their AI Chat is below, in development. |
+
+## 🔨 In development
+
+| Feature | Status |
+|---|---|
+| **AI prompt profiles** (the real feature inside their "Smart Profiles": named system-prompt modes in AI chat — theirs: 6, Chinese-only) | Approved and in progress on branch `smart-profiles`: a global library of 9 editable English profiles applying to **all five AI Voice backends**, switchable from the panel / by knob twist / per page, plus next/previous-page tile actions (their `nextProfile` parity). Rides on the AI Voice consolidation (branch `ai-voice`), which also adds the any-OpenAI-compatible-API chat backend. |
 
 ## ❌ Missing (the actual todo)
 
@@ -33,7 +41,6 @@ don't — update it when either side changes.
 |---|---|---|
 | **macOS / Linux support** | Multi-OS: Windows, macOS, Linux | **Large.** The launcher/editor are Electron (portable), but launch/volume/media/loopback-audio/reserved-display code is Windows-specific (README already flags this). Realistic only as a scoped "panel + apps, minus Windows-only extras" port. |
 | **AI-generated wallpapers** | "Wallpaper Generation by AI" + random wallpaper rotation | **Medium.** OQ has no wallpaper concept — pages are functional. Would be a new "ambient page" type + an image-gen backend (user's own key, same BYO pattern). Questionable value; the panel is usually showing something useful. |
-| **Smart Profiles (9 modes via knob)** | Knob-switchable AI modes (writing, coding, translation, research…) | **Small, mostly framing.** Multiple AI pages with per-page backend/model/prompt + page hotkeys already do this; what's missing is a packaged "profile" concept (per-page system prompt + a polished quick-switch). A per-page system-prompt option would close most of it. |
 | **AI-generated shortcut panels** | Hold the knob and say e.g. "create a shortcut set for Photoshop masking" — the AI generates a custom control set for that application, no manual macro programming (Kickstarter/copilot pages) | **Medium — and a natural fit.** OQ already has the two halves: AI routing (CLI agents / OWUI / any endpoint, no credits) and pages-as-JSON tile grids with `key`-type shortcut tiles. The missing piece is a "Generate panel with AI" flow in the editor (and/or by voice on the panel): prompt → validated tile JSON → new page for review. Probably the highest-value item on this list. |
 | **Game voice control** | Mentioned in their showcase | **Unclear scope.** Nearest OQ equivalents: global hotkeys, macros, LucidType. Needs a real definition of what theirs does before it's worth chasing. |
 

--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -1,9 +1,11 @@
 # DK-Suite feature parity
 
-What the commercial package advertises versus what open-quake ships. The comparison source is the
+What the commercial package advertises versus what open-quake ships. Comparison sources: the
 [DECOKEE Quake product page](https://www.decokee.com/products/decokee-quake-desktop-ai-assistant)
-(as advertised 2026-08); the open-quake side is current `main` (v0.5.7). This is the running list of
-what they have that we don't — update it when either side changes.
+plus their [Kickstarter](https://www.kickstarter.com/projects/decokee/decokee-quake-the-ultimate-desktop-ai-copilot)
+and [AI-copilot](https://www.decokee.com/pages/quake-ai-copilot) pages (as advertised 2026-08); the
+open-quake side is current `main` (v0.5.7). This is the running list of what they have that we
+don't — update it when either side changes.
 
 > open-quake is an independent community project, not affiliated with DECOKEE — see the
 > [README disclaimer](../README.md). Feature names in the "theirs" column are their marketing terms.
@@ -32,6 +34,7 @@ what they have that we don't — update it when either side changes.
 | **macOS / Linux support** | Multi-OS: Windows, macOS, Linux | **Large.** The launcher/editor are Electron (portable), but launch/volume/media/loopback-audio/reserved-display code is Windows-specific (README already flags this). Realistic only as a scoped "panel + apps, minus Windows-only extras" port. |
 | **AI-generated wallpapers** | "Wallpaper Generation by AI" + random wallpaper rotation | **Medium.** OQ has no wallpaper concept — pages are functional. Would be a new "ambient page" type + an image-gen backend (user's own key, same BYO pattern). Questionable value; the panel is usually showing something useful. |
 | **Smart Profiles (9 modes via knob)** | Knob-switchable AI modes (writing, coding, translation, research…) | **Small, mostly framing.** Multiple AI pages with per-page backend/model/prompt + page hotkeys already do this; what's missing is a packaged "profile" concept (per-page system prompt + a polished quick-switch). A per-page system-prompt option would close most of it. |
+| **AI-generated shortcut panels** | Hold the knob and say e.g. "create a shortcut set for Photoshop masking" — the AI generates a custom control set for that application, no manual macro programming (Kickstarter/copilot pages) | **Medium — and a natural fit.** OQ already has the two halves: AI routing (CLI agents / OWUI / any endpoint, no credits) and pages-as-JSON tile grids with `key`-type shortcut tiles. The missing piece is a "Generate panel with AI" flow in the editor (and/or by voice on the panel): prompt → validated tile JSON → new page for review. Probably the highest-value item on this list. |
 | **Game voice control** | Mentioned in their showcase | **Unclear scope.** Nearest OQ equivalents: global hotkeys, macros, LucidType. Needs a real definition of what theirs does before it's worth chasing. |
 
 ## Notes

--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -15,7 +15,7 @@ don't — update it when either side changes.
 
 | DK-Suite advertises | open-quake |
 |---|---|
-| AI Chat (credit-metered, 100 credits/mo free) | **Four AI apps, no credits**: real **Claude Code / Codex / Copilot agent sessions** (tools, approvals, your existing plan) + **Open WebUI** chat against your own models. *(In flight: one consolidated "AI Voice" app adding any OpenAI-compatible API by key.)* |
+| AI Chat (credit-metered, 100 credits/mo free) | One **AI Voice** app, five backends, **no credits**: real **Claude Code / Codex / Copilot agent sessions** (tools, approvals, your existing plan), **Open WebUI** chat against your own models, or **any OpenAI-compatible API by key** (OpenAI, DeepSeek, OpenRouter, LiteLLM/Ollama). |
 | Voice commands (press-and-speak) | Knob **hold-to-talk** everywhere + tap-to-toggle conversations; your own local Whisper STT (tts-sst), no cloud dependency. |
 | AI Meeting Assistant (record → transcribe → summarize) | Meeting app: stereo-split recording, auto start/stop, **speaker-diarized transcripts** (self-hosted), attendee-guided speaker ID via Outlook calendar, AI notes (summary/decisions/actions), per-meeting filing, **Joplin export**. Materially deeper than the advertised feature. |
 | Translation (Silver+ paid tiers) | **Live Translate**: word-by-word streaming captions (Soniox, ~$0.18/hr) or bring-your-own AI key (DeepSeek ≈ $0.10/hr, OpenAI, OpenRouter, LiteLLM/Ollama) with cross-sentence context, save-to-file, global hotkey. Not tier-gated. |
@@ -27,13 +27,12 @@ don't — update it when either side changes.
 | LED ring status for recording/translation/AI states | RGB ring is theme-driven and state-driven (listening/thinking/speaking/approval), fully configurable. |
 | Knob + touchscreen + gestures | Full knob support (rotate/click/double/hold), touch, page selector. |
 | Credit packs / subscriptions | Nothing metered. Costs are only what your own keys/servers cost. |
-| 9 Smart Profiles (knob-switchable "modes") | Teardown: their 9 "profiles" are **page layouts** (Discord/MeetAI/SysView/AI Chat/Music/Clock/…) — already open-quake **pages** with the knob selector and per-page hotkeys. The genuinely new piece inside their AI Chat is below, in development. |
+| 9 Smart Profiles (knob-switchable "modes") | Teardown: their 9 "profiles" are **page layouts** (Discord/MeetAI/SysView/AI Chat/Music/Clock/…) — already open-quake **pages** with the knob selector and per-page hotkeys. The real feature inside their AI Chat — named prompt modes (theirs: 6, Chinese-only) — **shipped as AI Profiles** (PR #23): 9 editable English instruction presets on all five AI Voice backends, switchable from the panel's Profile button / knob twist / per page, plus next/previous-page tile actions. |
 
 ## 🔨 In development
 
 | Feature | Status |
 |---|---|
-| **AI prompt profiles** (the real feature inside their "Smart Profiles": named system-prompt modes in AI chat — theirs: 6, Chinese-only) | Approved and in progress on branch `smart-profiles`: a global library of 9 editable English profiles applying to **all five AI Voice backends**, switchable from the panel / by knob twist / per page, plus next/previous-page tile actions (their `nextProfile` parity). Rides on the AI Voice consolidation (branch `ai-voice`), which also adds the any-OpenAI-compatible-API chat backend. |
 | **Screensaver page — wallpapers incl. AI-generated** (teardown: their wallpaper feature, the "Vivid" profile, is a manual crossfading image/video page — no idle detection) | In progress on branch `screensaver`: a media slideshow page (drop images/videos in a folder — your own ComfyUI/AI renders go straight in, no credits) plus built-in animated scenes (color waves, starfield, code rain, big clock), and it **auto-starts when the panel sits idle and wakes back to where you were** — which theirs can't do. |
 
 ## ❌ Missing (the actual todo)

--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -1,0 +1,43 @@
+# DK-Suite feature parity
+
+What the commercial package advertises versus what open-quake ships. The comparison source is the
+[DECOKEE Quake product page](https://www.decokee.com/products/decokee-quake-desktop-ai-assistant)
+(as advertised 2026-08); the open-quake side is current `main` (v0.5.7). This is the running list of
+what they have that we don't — update it when either side changes.
+
+> open-quake is an independent community project, not affiliated with DECOKEE — see the
+> [README disclaimer](../README.md). Feature names in the "theirs" column are their marketing terms.
+
+## ✅ Have (or have more)
+
+| DK-Suite advertises | open-quake |
+|---|---|
+| AI Chat (credit-metered, 100 credits/mo free) | **Four AI apps, no credits**: real **Claude Code / Codex / Copilot agent sessions** (tools, approvals, your existing plan) + **Open WebUI** chat against your own models. *(In flight: one consolidated "AI Voice" app adding any OpenAI-compatible API by key.)* |
+| Voice commands (press-and-speak) | Knob **hold-to-talk** everywhere + tap-to-toggle conversations; your own local Whisper STT (tts-sst), no cloud dependency. |
+| AI Meeting Assistant (record → transcribe → summarize) | Meeting app: stereo-split recording, auto start/stop, **speaker-diarized transcripts** (self-hosted), attendee-guided speaker ID via Outlook calendar, AI notes (summary/decisions/actions), per-meeting filing, **Joplin export**. Materially deeper than the advertised feature. |
+| Translation (Silver+ paid tiers) | **Live Translate**: word-by-word streaming captions (Soniox, ~$0.18/hr) or bring-your-own AI key (DeepSeek ≈ $0.10/hr, OpenAI, OpenRouter, LiteLLM/Ollama) with cross-sentence context, save-to-file, global hotkey. Not tier-gated. |
+| Instant answers | Any of the AI apps; hold the knob and ask. |
+| Drag-and-drop customization / preset app shortcuts | The PC-side editor: tile grids, merged tiles, per-page apps/dashboards, drag-and-drop, hotkeys. |
+| Music player | Music controller: now-playing, transport, app grid, lyrics. |
+| Smart home hub (use-case example) | First-class **Home Assistant integration**: entity tiles, real dashboards, MDI icons. |
+| Stock dashboard / expense automation / 3D-printer control (use-case examples) | Web-dashboard pages + shell/macro tiles + HA cover the same ground generically. |
+| LED ring status for recording/translation/AI states | RGB ring is theme-driven and state-driven (listening/thinking/speaking/approval), fully configurable. |
+| Knob + touchscreen + gestures | Full knob support (rotate/click/double/hold), touch, page selector. |
+| Credit packs / subscriptions | Nothing metered. Costs are only what your own keys/servers cost. |
+
+## ❌ Missing (the actual todo)
+
+| Feature | What they advertise | Lift for open-quake |
+|---|---|---|
+| **macOS / Linux support** | Multi-OS: Windows, macOS, Linux | **Large.** The launcher/editor are Electron (portable), but launch/volume/media/loopback-audio/reserved-display code is Windows-specific (README already flags this). Realistic only as a scoped "panel + apps, minus Windows-only extras" port. |
+| **AI-generated wallpapers** | "Wallpaper Generation by AI" + random wallpaper rotation | **Medium.** OQ has no wallpaper concept — pages are functional. Would be a new "ambient page" type + an image-gen backend (user's own key, same BYO pattern). Questionable value; the panel is usually showing something useful. |
+| **Smart Profiles (9 modes via knob)** | Knob-switchable AI modes (writing, coding, translation, research…) | **Small, mostly framing.** Multiple AI pages with per-page backend/model/prompt + page hotkeys already do this; what's missing is a packaged "profile" concept (per-page system prompt + a polished quick-switch). A per-page system-prompt option would close most of it. |
+| **Game voice control** | Mentioned in their showcase | **Unclear scope.** Nearest OQ equivalents: global hotkeys, macros, LucidType. Needs a real definition of what theirs does before it's worth chasing. |
+
+## Notes
+
+- Their "no cloud subscription required / open-source engine" claim still routes AI through their
+  credit system; open-quake's equivalent stance is stronger in practice (your CLIs, your servers,
+  your keys).
+- Hardware-only items (chassis, stand, transparent window, HDMI/USB wiring) are out of scope — both
+  sides run the same device.


### PR DESCRIPTION
Running comparison of the DECOKEE Quake product page's advertised features vs open-quake main (v0.5.7): what we have (or have more of), and the actual gap list — macOS/Linux support (large), AI wallpapers (medium, questionable value), packaged "smart profiles" (small; per-page system prompt would close most of it), game voice control (needs definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)