### PR TITLE
Smart Profiles: switchable AI instruction presets for AI Voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ It gives you:
   — one app, five backends: a real **Claude Code**, **Codex**, or **Copilot** agent session on the
   panel, or plain chat against your **Open WebUI** server or **any OpenAI-compatible API**
   (OpenAI, DeepSeek, OpenRouter, LiteLLM/Ollama — your own key) — tap the knob to start/stop a
-  hands-free conversation, with touch approvals and a full text transcript. → [Apps](docs/apps.md)
+  hands-free conversation, with touch approvals, a full text transcript, and switchable **AI
+  profiles** (Translator, Summarizer, Writer, … — editable instructions that reshape the AI in one
+  tap). → [Apps](docs/apps.md)
 - **Meeting recording → transcript → meeting notes** — the Meeting app **records your
   calls** (your mic on the left channel, everyone else on the right; can auto-start with
   Zoom/Teams calls and auto-stop on silence), then — right from the panel — sends

--- a/app/apivoice-session.js
+++ b/app/apivoice-session.js
@@ -28,6 +28,7 @@ function createApiVoiceAdapter({ resolveApi, log, client }) {
   let modelList = null;      // null until /models answers; then an array of id strings
   let stream = null;         // in-flight { destroy() } from streamChat
   let acc = '';              // assistant text accumulated for the current turn
+  let profilePrompt = '';    // active AI profile instruction; prepended as a system message per request
 
   function cfg() { return (resolveApi && resolveApi()) || {}; }
   function baseUrl() { return String(cfg().apiBaseUrl || '').trim().replace(/\/+$/, ''); }
@@ -64,7 +65,7 @@ function createApiVoiceAdapter({ resolveApi, log, client }) {
 
   return {
     // ---- lifecycle ----
-    start({ model }) {
+    start({ model, profilePrompt: pp }) {
       if (!baseUrl() || !String(cfg().apiKey || '').trim()) {
         say('start refused: API endpoint or key not configured');
         emitter.emit('error', { message: 'API endpoint not configured — set the URL and key in this page’s settings (config editor).' });
@@ -76,9 +77,13 @@ function createApiVoiceAdapter({ resolveApi, log, client }) {
       history = [];
       acc = '';
       modelPick = model || '';
+      profilePrompt = String(pp || '');
       fetchModels();
       return true;
     },
+    // AI profile switch — takes effect on the next request (the system message is prepended per
+    // send, so it can never be evicted by the history cap). Instant, no restart.
+    setProfilePrompt(text) { profilePrompt = String(text || ''); return true; },
     stop() {
       if (stream) { try { stream.destroy(); } catch (e) {} stream = null; }
       running = false;
@@ -103,7 +108,7 @@ function createApiVoiceAdapter({ resolveApi, log, client }) {
       acc = '';
       emitter.emit('assistant-start');
       let sawLength = false;
-      const payload = { model, stream: true, messages: history.slice() };
+      const payload = { model, stream: true, messages: (profilePrompt ? [{ role: 'system', content: profilePrompt }] : []).concat(history) };
       // DeepSeek v4 defaults to thinking mode (long reasoning delays, answer can land outside
       // content). Disable it; only for DeepSeek models — true-OpenAI endpoints reject unknown params.
       if (/deepseek/i.test(model)) payload.thinking = { type: 'disabled' };

--- a/app/claudevoice-adapter.js
+++ b/app/claudevoice-adapter.js
@@ -103,6 +103,21 @@ function createClaudeVoiceAdapter({ getServerPort, getUserDataPath, log }) {
     emitter.emit('exit', { stillRunning: session.isRunning() });
   });
 
+  let currentProfilePrompt = '';   // the active AI profile's instruction; folded into the system prompt
+
+  // Bundled voice prompt + the user's panel prompt file + the active AI profile, in that order.
+  function assembleSystemPrompt() {
+    let voicePrompt = '';
+    try { voicePrompt = fs.readFileSync(path.join(__dirname, 'claudevoice-voice-prompt.md'), 'utf8'); }
+    catch (e) { say('voice prompt not loaded: ' + e.message); }
+    try {
+      const userPrompt = readUserPrompt();
+      if (userPrompt) voicePrompt += (voicePrompt ? '\n\n' : '') + userPrompt;
+    } catch (e) { say('panel prompt file not loaded: ' + e.message); }
+    if (currentProfilePrompt) voicePrompt += (voicePrompt ? '\n\n' : '') + currentProfilePrompt;
+    return voicePrompt;
+  }
+
   function userPromptPath() { return path.join(getUserDataPath(), 'claude-panel-prompt.md'); }
   function ensureUserPromptFile() {
     const p = userPromptPath();
@@ -120,27 +135,29 @@ function createClaudeVoiceAdapter({ getServerPort, getUserDataPath, log }) {
     // session start rather than on checkbox change -- app options save through the generic grid-
     // config path with no per-option event, and re-syncing here is idempotent. A toggle takes
     // effect the next time a session starts.
-    start({ projectDir, mode, model, approvalsEnabled }) {
+    start({ projectDir, mode, model, approvalsEnabled, profilePrompt }) {
       try {
         if (approvalsEnabled) claudeVoiceApprovals.ensureHookInstalled(getUserDataPath(), say);
         else claudeVoiceApprovals.ensureHookRemoved(say);
       } catch (e) { say('hook sync failed: ' + e.message); }
-      let voicePrompt = '';
-      try { voicePrompt = fs.readFileSync(path.join(__dirname, 'claudevoice-voice-prompt.md'), 'utf8'); }
-      catch (e) { say('voice prompt not loaded: ' + e.message); }
-      try {
-        const userPrompt = readUserPrompt();
-        if (userPrompt) voicePrompt += (voicePrompt ? '\n\n' : '') + userPrompt;
-      } catch (e) { say('panel prompt file not loaded: ' + e.message); }
+      currentProfilePrompt = String(profilePrompt || '');
       session.start({
         projectDir,
         permissionMode: mode || 'manual',   // fail safe: ask, never bypass
         model: CLAUDE_VOICE_MODEL_PICKS.includes(model) ? model : '',
         port: getServerPort(),
         token,
-        systemPrompt: voicePrompt,
+        systemPrompt: assembleSystemPrompt(),
       });
       return true;
+    },
+    // AI profile switch: the CLI only reads its system prompt at launch, so a live switch swaps
+    // the child and resumes the conversation (the Mode/Model button mechanic). Not running -> just
+    // remember it for the next start.
+    setProfilePrompt(text) {
+      currentProfilePrompt = String(text || '');
+      if (!session.isRunning()) return true;
+      return session.setSystemPromptAppend(assembleSystemPrompt());
     },
     stop() {
       session.stop();

--- a/app/claudevoice-session.js
+++ b/app/claudevoice-session.js
@@ -192,6 +192,16 @@ function createClaudeVoiceSession(options) {
       return true;
     },
     permissionMode() { return permissionMode; },
+    // Same resume-restart trick for the system-prompt append (AI profile switches): the CLI only
+    // reads --append-system-prompt at launch, so swap the child and resume the conversation.
+    setSystemPromptAppend(text) {
+      if (!sessionId) return false;
+      stopping = true; stopChild(); stopping = false;
+      systemPromptAppend = text || '';
+      resumeSessionId = sessionId;
+      launch();
+      return true;
+    },
     // Same resume-restart trick for the model ('' switches back to the account default).
     setModel(pick) {
       if (!sessionId) return false;

--- a/app/claudevoiceview.html
+++ b/app/claudevoiceview.html
@@ -147,6 +147,24 @@
     font-weight: 600; cursor: pointer; text-align: left; padding: 10px 16px; }
   .modeOpt small { display: block; font-size: 13px; font-weight: 400; color: var(--muted); margin-top: 2px; }
   .modeOpt.current { border-color: var(--accent); outline: 2px solid var(--accent); outline-offset: -2px; }
+  /* AI profile picker (Smart Profiles): full-screen grid of big touch cards — all nine visible at
+     1920x480 with no scrolling; the current profile is a filled accent card. */
+  #profileOverlay { position: fixed; inset: 0; background: rgba(0,0,0,.55); display: flex;
+    align-items: center; justify-content: center; padding: 24px; z-index: 45; user-select: none; }
+  #profileOverlay.hidden { display: none; }
+  #profileCard { width: min(1600px, 100%); background: var(--surf); border: 1px solid var(--tile-bd);
+    border-radius: 16px; padding: 20px 24px; box-shadow: 0 12px 40px rgba(0,0,0,.4); }
+  #profileHead { display: flex; align-items: center; margin-bottom: 14px; }
+  #profileTitle { font-size: 18px; font-weight: 700; }
+  #profileCancel { margin-left: auto; min-height: 48px; min-width: 110px; border-radius: 10px;
+    border: 1px solid var(--tile-bd); background: var(--surf2); color: var(--fg); font-size: 15px;
+    font-weight: 600; cursor: pointer; }
+  #profileGrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  .profileOpt { min-height: 88px; border-radius: 14px; border: 1px solid var(--tile-bd);
+    background: var(--surf2); color: var(--fg); font-size: 24px; font-weight: 700; cursor: pointer;
+    padding: 10px 16px; text-align: center; overflow: hidden; }
+  .profileOpt:active { background: var(--tile-bd); }
+  .profileOpt.current { background: var(--accent); color: var(--accent-fg, #04120b); border-color: transparent; }
   #modeCancel { min-height: 48px; min-width: 96px; border-radius: 10px; border: 1px solid var(--tile-bd);
     background: var(--surf2); color: var(--fg); font-size: 15px; font-weight: 600; cursor: pointer; }
 
@@ -243,6 +261,7 @@
      keeps the accent so the primary action stays unmistakable. */
   #approvalAlways { background: var(--surf2); color: var(--fg); border: 1px solid var(--tile-bd); }
   #approvalAlways.hidden { display: none; }
+  .vpBtn.hidden { display: none; }   /* meta-driven hiding of rail buttons (Project/Mode/Profile) */
   #approvalApprove { background: var(--accent); color: var(--accent-fg, #04120b); }
 </style>
 </head>
@@ -270,6 +289,7 @@
         </button>
       </div>
       <button id="vpProject" class="vpBtn" type="button">Change folder</button>
+      <button id="vpProfile" class="vpBtn" type="button">Profile</button>
       <button id="vpSettings" class="vpBtn" type="button">Settings</button>
       <button id="vpMode" class="vpBtn" type="button">Mode</button>
       <div id="project"></div>
@@ -305,6 +325,12 @@
         <button class="modeOpt" data-mode="bypassPermissions" type="button">Full auto<small>No prompts at all — use with care</small></button>
       </div>
       <div style="display:flex;justify-content:flex-end"><button id="modeCancel" type="button">Cancel</button></div>
+    </div>
+  </div>
+  <div id="profileOverlay" class="hidden">
+    <div id="profileCard">
+      <div id="profileHead"><div id="profileTitle">AI profile</div><button id="profileCancel" type="button">Cancel</button></div>
+      <div id="profileGrid"></div>
     </div>
   </div>
   <div id="settingsOverlay" class="hidden">

--- a/app/claudevoiceview.html
+++ b/app/claudevoiceview.html
@@ -18,6 +18,9 @@
      Settings. Icon buttons follow the Music page's transport aesthetic exactly: circular, 2px
      border, soft gradient fill, currentColor SVG glyphs, scale-down on press. All chrome, so
      user-select:none. */
+  /* Height budget: title + icon row + THREE vpBtns (Profile/Settings/Mode) + folder name fit 480px.
+     Change folder lives in the Settings overlay (rarely used), which is what freed the Profile
+     button's slot without shrinking anything. */
   #voicePanel { flex: 0 0 284px; display: flex; flex-direction: column; gap: 14px; align-items: center;
     justify-content: space-between; user-select: none; }
   #vizRow { display: flex; gap: 16px; justify-content: center; }
@@ -262,6 +265,7 @@
   #approvalAlways { background: var(--surf2); color: var(--fg); border: 1px solid var(--tile-bd); }
   #approvalAlways.hidden { display: none; }
   .vpBtn.hidden { display: none; }   /* meta-driven hiding of rail buttons (Project/Mode/Profile) */
+  #project.hidden { display: none; } /* chat backends: no folders, so no "(no project set)" line */
   #approvalApprove { background: var(--accent); color: var(--accent-fg, #04120b); }
 </style>
 </head>
@@ -288,7 +292,6 @@
           <svg class="ban" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10.6"/><line x1="4.6" y1="4.6" x2="19.4" y2="19.4"/></svg>
         </button>
       </div>
-      <button id="vpProject" class="vpBtn" type="button">Change folder</button>
       <button id="vpProfile" class="vpBtn" type="button">Profile</button>
       <button id="vpSettings" class="vpBtn" type="button">Settings</button>
       <button id="vpMode" class="vpBtn" type="button">Mode</button>
@@ -349,6 +352,9 @@
           <p class="hint" style="margin:0">Pause tolerance = how long you can go quiet mid-sentence before the utterance is sent. Raise it if swallowing or thinking pauses cut you off.</p>
         </div>
         <div class="scol">
+          <button id="folderPickBtn" class="pickRow" type="button">
+            <span class="pickName">Folder</span><span id="folderPickVal" class="pickVal"></span><span class="pickChevron">›</span>
+          </button>
           <button id="micPickBtn" class="pickRow" type="button">
             <span class="pickName">Microphone</span><span id="micPickVal" class="pickVal"></span><span class="pickChevron">›</span>
           </button>

--- a/app/claudevoiceview.html
+++ b/app/claudevoiceview.html
@@ -349,12 +349,12 @@
             <button id="pauseMinus" class="stepBtn" type="button">–</button>
             <span id="pauseVal" class="stepVal"></span>
             <button id="pausePlus" class="stepBtn" type="button">+</button></div>
-          <p class="hint" style="margin:0">Pause tolerance = how long you can go quiet mid-sentence before the utterance is sent. Raise it if swallowing or thinking pauses cut you off.</p>
-        </div>
-        <div class="scol">
+          <p class="hint" style="margin:0 0 12px">Pause tolerance = how long you can go quiet mid-sentence before the utterance is sent. Raise it if swallowing or thinking pauses cut you off.</p>
           <button id="folderPickBtn" class="pickRow" type="button">
             <span class="pickName">Folder</span><span id="folderPickVal" class="pickVal"></span><span class="pickChevron">›</span>
           </button>
+        </div>
+        <div class="scol">
           <button id="micPickBtn" class="pickRow" type="button">
             <span class="pickName">Microphone</span><span id="micPickVal" class="pickVal"></span><span class="pickChevron">›</span>
           </button>

--- a/app/claudevoiceview.html
+++ b/app/claudevoiceview.html
@@ -364,8 +364,8 @@
           <button id="modelPickBtn" class="pickRow" type="button">
             <span class="pickName">Model</span><span id="modelPickVal" class="pickVal"></span><span class="pickChevron">›</span>
           </button>
-          <div class="srow" style="margin:0"><button id="ttsTestBtn" class="vpBtn" type="button">🔊 Test speech</button>
-            <span class="hint">Speaks Claude's last reply through the configured voice.</span></div>
+          <div class="srow" style="margin:0"><button id="ttsTestBtn" class="vpBtn" type="button" style="width:auto;flex:0 0 auto;padding:8px 20px">🔊 Test speech</button>
+            <span class="hint" style="flex:1;min-width:0">Speaks the last reply through the configured voice.</span></div>
         </div>
       </div>
       <div class="srow" style="justify-content:flex-end;margin:12px 0 0"><button id="settingsClose" type="button">Done</button></div>

--- a/app/claudevoiceview.js
+++ b/app/claudevoiceview.js
@@ -164,6 +164,9 @@ function connectEvents() {
       showApprovalOverlay(msg.requestId, msg.toolName, msg.toolInput);
     } else if (msg.type === 'approval-decision' || msg.type === 'approval-timeout') {
       if (msg.requestId === pendingApprovalRequestId) hideApprovalOverlay();
+    } else if (msg.type === 'profile') {
+      currentProfileId = msg.id || '';
+      syncProfileUI();
     } else if (msg.type === 'permission-mode') {
       currentMode = msg.mode || currentMode;
       syncModeUI();
@@ -291,6 +294,11 @@ function applyMeta(meta) {
   if (meta.models && meta.models.length) {
     MODEL_PICKS = meta.models.map(function (m) { return [m.id, m.label]; });
     syncPickButtons();
+  }
+  if (meta.profiles) {
+    PROFILES = meta.profiles;
+    if (typeof meta.profile === 'string') currentProfileId = meta.profile;
+    syncProfileUI();
   }
 }
 fetch(BASE + '/state', { cache: 'no-store' }).then(function (r) { return r.json(); })
@@ -774,6 +782,44 @@ applyPause();
 // Switching restarts the claude process with --resume + the new --permission-mode (mode is a
 // launch-only CLI flag; the mid-session control message is undocumented/unsupported). The
 // conversation itself carries over -- expect a ~2s pause before the next turn responds.
+// ---- AI profile (Smart Profiles): big-card grid picker, list delivered via meta ----
+var PROFILES = [];            // [{id, name}] from meta.profiles
+var currentProfileId = '';
+function syncProfileUI() {
+  var cur = null;
+  for (var i = 0; i < PROFILES.length; i++) if (PROFILES[i].id === currentProfileId) cur = PROFILES[i];
+  $('vpProfile').textContent = cur ? 'Profile: ' + cur.name : 'Profile';
+  $('vpProfile').classList.toggle('hidden', !PROFILES.length);
+  document.querySelectorAll('.profileOpt').forEach(function (b) {
+    b.classList.toggle('current', b.getAttribute('data-profile') === currentProfileId);
+  });
+}
+function renderProfileGrid() {
+  var grid = $('profileGrid');
+  grid.innerHTML = '';
+  PROFILES.forEach(function (p) {
+    var b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'profileOpt';
+    b.setAttribute('data-profile', p.id);
+    b.textContent = p.name;
+    b.onclick = function () {
+      $('profileOverlay').classList.add('hidden');
+      if (p.id === currentProfileId) return;
+      fetch(BASE + '/profile', {
+        method: 'POST', cache: 'no-store', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: p.id }),
+      }).then(function (r) { return r.json(); })
+        .then(function (r) { if (!r || !r.ok) setStatus(conversationOpen ? 'listening' : 'idle', 'Profile switch failed.'); })
+        .catch(function () { setStatus('error', 'Could not reach the panel server.'); });
+    };
+    grid.appendChild(b);
+  });
+  syncProfileUI();
+}
+$('vpProfile').onclick = function () { renderProfileGrid(); $('profileOverlay').classList.remove('hidden'); };
+$('profileCancel').onclick = function () { $('profileOverlay').classList.add('hidden'); };
+
 var MODE_LABELS = { manual: 'Manual', acceptEdits: 'Accept edits', plan: 'Plan', bypassPermissions: 'Full auto' };
 var currentMode = '';
 function syncModeUI() {

--- a/app/claudevoiceview.js
+++ b/app/claudevoiceview.js
@@ -26,7 +26,7 @@ var BASE = '/' + (location.pathname.split('/')[1] || 'ai-voice') + '/' + BACKEND
 })();
 
 var projectDir = Q.get('projectDir') || '';
-$('project').textContent = projectDir ? projectDir.split(/[\\/]/).filter(Boolean).pop() : '(no project set)';
+setProjectHeader(projectDir);   // rail label + the Settings overlay's Folder row value
 
 function esc(s) {
   var d = document.createElement('div');
@@ -268,7 +268,10 @@ function applyMeta(meta) {
   $('approvalAlways').classList.toggle('hidden', !meta.approvalAlways);   // only agents whose protocol supports session-wide approval
   // Chat-only backends (owui/api) have no working directory and no permission modes -- hide the
   // buttons instead of leaving dead claude-shaped controls on screen.
-  $('vpProject').classList.toggle('hidden', meta.hasProject === false);
+  // Chat backends (owui/api) have no working directory: hide the rail's folder-name line and the
+  // Settings overlay's Folder row.
+  $('project').classList.toggle('hidden', meta.hasProject === false);
+  $('folderPickBtn').style.display = meta.hasProject === false ? 'none' : '';
   $('vpMode').classList.toggle('hidden', !(meta.modes && meta.modes.length));
   if (meta.modes && meta.modes.length) {
     MODE_LABELS = {};
@@ -661,7 +664,10 @@ function onVADLevel(level) {
 // first (accent border), then everything under the root alphabetically; the current folder is the
 // single solid accent-filled pill.
 function baseName(p) { return String(p || '').split(/[\\/]/).filter(Boolean).pop() || p; }
-function setProjectHeader(dir) { $('project').textContent = dir ? baseName(dir) : '(no folder set)'; }
+function setProjectHeader(dir) {
+  $('project').textContent = dir ? baseName(dir) : '(no folder set)';
+  $('folderPickVal').textContent = dir ? baseName(dir) : 'not set';
+}
 var projRoot = '';
 function pickProject(dir) {
   $('projectOverlay').classList.add('hidden');
@@ -737,7 +743,8 @@ function wireScrollButtons(listId, upId, downId) {
 }
 wireScrollButtons('projList', 'projScrollUp', 'projScrollDown');
 wireScrollButtons('devList', 'devScrollUp', 'devScrollDown');
-$('vpProject').onclick = function () { openProjectOverlay(); };
+// Folder lives in Settings (rarely changed) — the row closes Settings and opens the folder picker.
+$('folderPickBtn').onclick = function () { $('settingsOverlay').classList.add('hidden'); openProjectOverlay(); };
 $('projCancel').onclick = function () { $('projectOverlay').classList.add('hidden'); };
 $('projCreate').onclick = function () {
   var name = $('projNewName').value.trim();

--- a/app/claudevoiceview.js
+++ b/app/claudevoiceview.js
@@ -581,7 +581,7 @@ $('devCancel').onclick = function () { $('devOverlay').classList.add('hidden'); 
 // start/end on its own, no holding anything down), a second tap closes it. See the plan's hard
 // constraint #4 -- push-to-talk was explicitly rejected.
 var conversationOpen = false;
-var vadHangoverMs = parseInt(Q.get('vadHangoverMs'), 10) || 800;
+var vadHangoverMs = parseInt(Q.get('vadHangoverMs'), 10) || 400;   // 0.4s default — snappier out of the box (matches LucidType)
 var vad = window.createClaudeVoiceVAD ? window.createClaudeVoiceVAD({ hangoverMs: vadHangoverMs }) : null;
 function onVADSpeechStart() {
   if (suppressVAD) return;

--- a/app/codexvoice-session.js
+++ b/app/codexvoice-session.js
@@ -83,6 +83,8 @@ function createCodexVoiceAdapter({ log }) {
   let nextId = 0;
   let pending = new Map();      // request id -> {resolve, reject}
   let queuedTurns = [];         // sendTurn() calls made before the thread handshake finished
+  let profilePrompt = '';       // active AI profile instruction (no protocol slot -> first-turn prefix)
+  let profileInjectPending = false;   // true = the next turn carries the profile prefix
   let threadId = null;
   let resumeThreadId = null;    // survive an adapter restart with the conversation intact
   let activeTurnId = null;
@@ -329,6 +331,13 @@ function createCodexVoiceAdapter({ log }) {
   }
 
   function startTurn(text) {
+    // AI profile: codex's protocol has no instructions slot, so the profile rides as a prefix on
+    // the FIRST turn after a session start or profile switch (LucidType's combined-prompt trick).
+    // The transcript shows the user's own words — the host records the unprefixed text.
+    if (profileInjectPending && profilePrompt) {
+      text = '[Instructions for this conversation — follow them in every reply]\n' + profilePrompt + '\n[End of instructions]\n\n' + text;
+      profileInjectPending = false;
+    }
     // The host serializes turns (CLI semantics: one in flight, later entries queue), so a
     // concurrent turn/start can't happen. turn/interrupt stays available via interrupt() for an
     // explicit Stop control someday -- it is deliberately NOT wired to new turns or mute.
@@ -352,13 +361,15 @@ function createCodexVoiceAdapter({ log }) {
 
   return {
     // ---- lifecycle (host adapter contract; see voicepanel-host.js header) ----
-    start({ projectDir: dir, mode: pick, model }) {
+    start({ projectDir: dir, mode: pick, model, profilePrompt: pp }) {
       if (!findCodexExe()) {
         say('codex CLI not found on PATH');
         emitter.emit('error', { message: 'codex CLI not found on PATH' });
         return false;
       }
       stopProc('superseded by a new session');
+      profilePrompt = String(pp || '');
+      profileInjectPending = !!profilePrompt;
       projectDir = dir;
       pick = CODEX_LEGACY_MODES[pick] || pick;   // earlier panel builds saved different preset ids
       mode = CODEX_MODE_PRESETS[pick] ? pick : CODEX_DEFAULT_MODE;
@@ -380,6 +391,8 @@ function createCodexVoiceAdapter({ log }) {
       startTurn(text);
       return true;
     },
+    // AI profile switch mid-session: the new instruction rides on the next turn.
+    setProfilePrompt(text) { profilePrompt = String(text || ''); profileInjectPending = !!profilePrompt; return true; },
     isRunning() { return !!proc; },
     sessionId() { return threadId; },
     projectDir() { return projectDir; },

--- a/app/config.js
+++ b/app/config.js
@@ -473,6 +473,43 @@
       if (inputs.length) inputs[inputs.length - 1].focus();
     };
   }
+  // ---- AI Profiles rows (Settings -> AI Profiles): name + prompt per row, add/remove ----
+  // Same live-edit model as the custom-shortcut rows: mutate config.settings.aiProfiles in place,
+  // markDirty(), Save persists. Ids are stable (never edited); new rows mint one.
+  function aiProfileRowsHtml(list) {
+    const rows = Array.isArray(list) ? list : [];
+    if (!rows.length) return '<p class="hint">No profiles yet — add one below.</p>';
+    return rows.map((p, i) => `<div class="row" data-idx="${i}" style="margin-top:10px;align-items:flex-start">
+        <input class="apName" placeholder="Profile name" value="${esc(p.name || '')}" style="width:200px">
+        <textarea class="apPrompt" placeholder="Instruction for the AI (empty = plain chat)" rows="2" style="flex:1;margin-left:8px;font-family:inherit">${esc(p.prompt || '')}</textarea>
+        <button class="apRemove" type="button" data-rm="${i}" title="Remove" style="margin-left:8px">✕</button>
+      </div>`).join('');
+  }
+  function wireAiProfileRows() {
+    const host = document.getElementById('sAiProfileRows');
+    if (!host) return;
+    const list = () => { if (!config.settings) config.settings = {}; if (!Array.isArray(config.settings.aiProfiles)) config.settings.aiProfiles = []; return config.settings.aiProfiles; };
+    const redraw = () => { host.innerHTML = aiProfileRowsHtml(list()); wireRows(); };
+    function wireRows() {
+      host.querySelectorAll('.apName').forEach((inp, i) => {
+        inp.oninput = e => { const l = list(); if (l[i]) { l[i].name = e.target.value; markDirty(); } };
+      });
+      host.querySelectorAll('.apPrompt').forEach((ta, i) => {
+        ta.oninput = e => { const l = list(); if (l[i]) { l[i].prompt = e.target.value; markDirty(); } };
+      });
+      host.querySelectorAll('.apRemove').forEach(btn => {
+        btn.onclick = () => { list().splice(parseInt(btn.getAttribute('data-rm'), 10), 1); markDirty(); redraw(); };
+      });
+    }
+    wireRows();
+    const addBtn = document.getElementById('sAiProfileAdd');
+    if (addBtn) addBtn.onclick = () => {
+      list().push({ id: 'p' + Date.now().toString(36), name: '', prompt: '' });
+      markDirty(); redraw();
+      const inputs = host.querySelectorAll('.apName');
+      if (inputs.length) inputs[inputs.length - 1].focus();
+    };
+  }
   function officeOptionDefault(def, key) {
     const option = (def.options || []).find(item => item.key === key);
     return option ? option.default : '';
@@ -1646,7 +1683,10 @@
           <input id="cvProjectsRoot" value="${esc(cvVal('projectsRoot', ''))}" style="flex:1">
           <button id="cvProjectsRootBrowse" type="button">Browse…</button></div>
         <p class="hint">The folder the panel's Change folder list scans.</p>`) + `
-        <p class="hint">Voice STT/TTS servers are set globally under <b>Settings → TTS/STT</b>. Override them for just this page in <b>Advanced settings</b> below.</p>` + (!cvModes ? '' : `
+        <p class="hint">Voice STT/TTS servers are set globally under <b>Settings → TTS/STT</b>. Override them for just this page in <b>Advanced settings</b> below.</p>
+        <div class="row" style="margin-top:10px"><label>Default profile</label>
+          <select id="cvProfile" style="flex:1">${(((config.settings || {}).aiProfiles) || []).map((p, i) => `<option value="${esc(p.id)}" ${(cvVal('profilePick', '') || (((config.settings || {}).aiProfiles) || [{}])[0].id) === p.id ? 'selected' : ''}>${esc(p.name || '(unnamed)')}</option>`).join('')}</select></div>
+        <p class="hint">The AI profile this page starts with — a named instruction that shapes the AI (translate, summarize, write…). Switch live from the panel's <b>Profile</b> button; manage the list under <b>Settings → AI Profiles</b>.</p>` + (!cvModes ? '' : `
         <div class="row" style="margin-top:10px"><label>Permission mode</label>
           <select id="cvPermMode" style="flex:1">${cvModes.choices.map(c => `<option value="${esc(c[0])}" ${cvMode === c[0] ? 'selected' : ''}>${esc(c[1])}</option>`).join('')}</select></div>`) + (cvBackend === 'claude' ? `
         <div class="row"><label>Touch approval</label>
@@ -1871,6 +1911,8 @@
       if (cvProjectsRootBrowse) cvProjectsRootBrowse.onclick = async () => { const p = await configApi.pickFolder(); if (p) { document.getElementById('cvProjectsRoot').value = p; setOpt('projectsRoot', p); } };
       const cvPermMode = document.getElementById('cvPermMode');
       if (cvPermMode) cvPermMode.onchange = e => setOpt('permissionMode', e.target.value);
+      const cvProfile = document.getElementById('cvProfile');
+      if (cvProfile) cvProfile.onchange = e => setOpt('profilePick', e.target.value);
       const cvApprovals = document.getElementById('cvApprovals');   // claude-only rows
       if (cvApprovals) cvApprovals.onchange = e => setOpt('approvalsEnabled', e.target.checked);
       const cvEditPrompt = document.getElementById('cvEditPrompt');
@@ -2635,6 +2677,12 @@
 
       <p class="hint">The default STT (Whisper) and TTS (Piper) servers for every voice app and meeting dictation. Each service has its own host + port, so they can run on different machines. Enter your server's IP, or run <a href="#" id="ttsHelperLink">tts-stt-windows</a> on any Windows box to provide both and set the host to <code>127.0.0.1</code>. A page can override these in its <b>Advanced settings</b>. Remember to Save.</p>`;
 
+    // AI Profiles (Smart Profiles): the global library the AI Voice app's Profile picker offers.
+    const apHtml = `
+      <p class="sectitle">AI Profiles</p>
+      <p class="hint">Named instructions for the <b>AI Voice</b> app — pick one on the panel (the Profile button) and the AI behaves accordingly: translate, summarize, write, and so on. The instruction is sent to the AI as its role for the conversation. An empty instruction (General Chat) means plain, unmodified chat. Every AI Voice page remembers its own current profile. Remember to Save.</p>
+      <div id="sAiProfileRows">${aiProfileRowsHtml((config.settings || {}).aiProfiles)}</div>
+      <button id="sAiProfileAdd" type="button" style="margin-top:10px">+ Add profile</button>`;
     el.innerHTML = `
       <p class="sectitle">Settings</p>
       <div class="tabbar">
@@ -2644,11 +2692,12 @@
         <button id="tabApps" class="tab${tab === 'apps' ? ' on' : ''}">Apps</button>
         <button id="tabDi" class="tab${tab === 'dropin' ? ' on' : ''}">Drop-In Apps</button>
         <button id="tabAuth" class="tab${tab === 'auth' ? ' on' : ''}">Auth</button>
+        <button id="tabAp" class="tab${tab === 'aiprofiles' ? ' on' : ''}">AI Profiles</button>
         <button id="tabMe" class="tab${tab === 'meeting' ? ' on' : ''}">Meeting</button>
         <button id="tabTts" class="tab${tab === 'ttsstt' ? ' on' : ''}">TTS/STT</button>
         <button id="tabMon" class="tab${tab === 'monitor' ? ' on' : ''}">Monitor</button>
       </div>
-      ${tab === 'software' ? swHtml : tab === 'hardware' ? hwHtml : tab === 'theme' ? thHtml : tab === 'apps' ? appsHtml : tab === 'dropin' ? diHtml : tab === 'auth' ? authHtml : tab === 'meeting' ? meHtml : tab === 'ttsstt' ? ttsHtml : monHtml}
+      ${tab === 'software' ? swHtml : tab === 'hardware' ? hwHtml : tab === 'theme' ? thHtml : tab === 'apps' ? appsHtml : tab === 'dropin' ? diHtml : tab === 'auth' ? authHtml : tab === 'aiprofiles' ? apHtml : tab === 'meeting' ? meHtml : tab === 'ttsstt' ? ttsHtml : monHtml}
       <div class="row" style="margin-top:22px"><button id="sBack">← Back to pages</button></div>`;
 
     document.getElementById('tabSw').onclick = () => { settingsTab = 'software'; renderSettings(); };
@@ -2657,6 +2706,8 @@
     document.getElementById('tabApps').onclick = () => { settingsTab = 'apps'; renderSettings(); };
     document.getElementById('tabDi').onclick = () => { settingsTab = 'dropin'; renderSettings(); };
     document.getElementById('tabAuth').onclick = () => { settingsTab = 'auth'; renderSettings(); };
+    document.getElementById('tabAp').onclick = () => { settingsTab = 'aiprofiles'; renderSettings(); };
+    wireAiProfileRows();   // no-op unless the AI Profiles tab is showing
     document.getElementById('tabMe').onclick = () => { settingsTab = 'meeting'; renderSettings(); };
     document.getElementById('tabTts').onclick = () => { settingsTab = 'ttsstt'; renderSettings(); };
     document.getElementById('tabMon').onclick = () => { settingsTab = 'monitor'; renderSettings(); };

--- a/app/copilotvoice-session.js
+++ b/app/copilotvoice-session.js
@@ -68,6 +68,8 @@ function createCopilotVoiceAdapter({ log }) {
   let nextId = 0;
   let pending = new Map();          // request id -> {resolve, reject}
   let queuedTurns = [];             // sendTurn() calls made before the handshake finished
+  let profilePrompt = '';           // active AI profile instruction (no protocol slot -> first-turn prefix)
+  let profileInjectPending = false;   // true = the next turn carries the profile prefix
   let sessionId = null;
   let projectDir = null;
   let mode = COPILOT_DEFAULT_MODE;
@@ -290,6 +292,13 @@ function createCopilotVoiceAdapter({ log }) {
   }
 
   function startTurn(text) {
+    // AI profile: copilot's ACP session/prompt has no instructions slot, so the profile rides as a
+    // prefix on the FIRST turn after a session start or profile switch. The transcript shows the
+    // user's own words — the host records the unprefixed text.
+    if (profileInjectPending && profilePrompt) {
+      text = '[Instructions for this conversation — follow them in every reply]\n' + profilePrompt + '\n[End of instructions]\n\n' + text;
+      profileInjectPending = false;
+    }
     turnText = '';
     turnInFlight = true;
     emitter.emit('assistant-start');
@@ -310,13 +319,15 @@ function createCopilotVoiceAdapter({ log }) {
 
   return {
     // ---- lifecycle (host adapter contract; see voicepanel-host.js header) ----
-    start({ projectDir: dir, mode: pick, model }) {
+    start({ projectDir: dir, mode: pick, model, profilePrompt: pp }) {
       if (!findCopilotExe()) {
         say('copilot CLI not found on PATH');
         emitter.emit('error', { message: 'copilot CLI not found on PATH' });
         return false;
       }
       stopProc('superseded by a new session');
+      profilePrompt = String(pp || '');
+      profileInjectPending = !!profilePrompt;
       projectDir = dir;
       mode = COPILOT_MODE_PRESETS[pick] ? pick : COPILOT_DEFAULT_MODE;
       sessionId = null;
@@ -338,6 +349,8 @@ function createCopilotVoiceAdapter({ log }) {
       startTurn(text);
       return true;
     },
+    // AI profile switch mid-session: the new instruction rides on the next turn.
+    setProfilePrompt(text) { profilePrompt = String(text || ''); profileInjectPending = !!profilePrompt; return true; },
     isRunning() { return !!proc; },
     sessionId() { return sessionId; },
     projectDir() { return projectDir; },

--- a/app/main.js
+++ b/app/main.js
@@ -348,6 +348,7 @@ function migrateConfig(c) {
     }
   });
   voiceConfig.migrateVoiceConfig(c);   // legacy per-page wyoming* -> global config.settings.voice + per-page override
+  voiceConfig.ensureAiProfiles(c);     // seed the Smart Profiles library once (user edits are never touched)
   return c;
 }
 // SystemView (System Monitor) is RETIRED: its metrics layer spawned continuous PowerShell

--- a/app/owuivoice-session.js
+++ b/app/owuivoice-session.js
@@ -32,6 +32,7 @@ function createOwuiVoiceAdapter({ resolveOwui, log, client }) {
   let modelList = null;      // null until /api/models answers; then an array of id strings
   let stream = null;         // in-flight { destroy() } from streamChat
   let acc = '';              // assistant text accumulated for the current turn
+  let profilePrompt = '';    // active AI profile instruction; prepended as a system message per request
 
   function cfg() { return (resolveOwui && resolveOwui()) || {}; }
   function endpoint() { return owui.normalizeOwuiUrl(cfg().url); }
@@ -66,7 +67,7 @@ function createOwuiVoiceAdapter({ resolveOwui, log, client }) {
 
   return {
     // ---- lifecycle ----
-    start({ model }) {
+    start({ model, profilePrompt: pp }) {
       if (!endpoint()) {
         say('start refused: no usable Open WebUI URL configured');
         emitter.emit('error', { message: "Open WebUI connection not configured — set the URL on the editor's Auth tab." });
@@ -78,9 +79,13 @@ function createOwuiVoiceAdapter({ resolveOwui, log, client }) {
       history = [];
       acc = '';
       modelPick = model || '';
+      profilePrompt = String(pp || '');
       fetchModels();
       return true;
     },
+    // AI profile switch — takes effect on the next request (system message prepended per send,
+    // never evicted by the history cap). Instant, no restart.
+    setProfilePrompt(text) { profilePrompt = String(text || ''); return true; },
     stop() {
       if (stream) { try { stream.destroy(); } catch (e) {} stream = null; }
       running = false;
@@ -105,7 +110,7 @@ function createOwuiVoiceAdapter({ resolveOwui, log, client }) {
       acc = '';
       emitter.emit('assistant-start');
       let sawLength = false;
-      stream = owui.streamChat(ep.chatUrl, { model, stream: true, messages: history.slice() }, String(cfg().apiKey || ''), TURN_TIMEOUT_MS, {
+      stream = owui.streamChat(ep.chatUrl, { model, stream: true, messages: (profilePrompt ? [{ role: 'system', content: profilePrompt }] : []).concat(history) }, String(cfg().apiKey || ''), TURN_TIMEOUT_MS, {
         onDelta: t => { acc += t; emitter.emit('assistant-delta', { text: t }); },
         onDone: ({ finishReason }) => {
           sawLength = finishReason === 'length';

--- a/app/sysserver.js
+++ b/app/sysserver.js
@@ -432,6 +432,7 @@ const VOICE_POST_SUFFIXES = new Set([
   '/session/start',
   '/session/stop',
   '/permission-mode',
+  '/profile',
   '/model',
   '/tts',
   '/option',
@@ -650,6 +651,14 @@ async function handler(req, res) {
       const mode = body && typeof body.mode === 'string' ? body.mode : '';
       if (!mode || !h.setPermissionMode) return done(res, false);
       let ok = false; try { ok = !!h.setPermissionMode(mode); } catch (e) {}
+      return done(res, ok);
+    }
+    // AI profile switch (Smart Profiles): the page's picker posts the chosen profile id.
+    if (voicePath === '/profile' && req.method === 'POST') {
+      let body; try { body = await readJsonBody(req); } catch (e) { return done(res, false); }
+      const id = body && typeof body.id === 'string' ? body.id : null;
+      if (id == null || !h.setProfile) return done(res, false);
+      let ok = false; try { ok = !!h.setProfile(id); } catch (e) {}
       return done(res, ok);
     }
     if (voicePath === '/model' && req.method === 'POST') {

--- a/app/voiceConfig.js
+++ b/app/voiceConfig.js
@@ -93,6 +93,41 @@ function resolveLucidEndpoints(settings, grids) {
   return resolveVoiceEndpoints(settings, (g && g.options) || {});
 }
 
+// ---- AI Profiles (Smart Profiles) ----
+// A global library of named system-prompt presets for the AI Voice app. Seeded once; the user
+// edits them on the Settings -> AI Profiles tab. "General Chat" ships with an EMPTY prompt so the
+// default behavior is exactly the pre-feature behavior on every backend.
+const DEFAULT_AI_PROFILES = [
+  { id: 'chat', name: 'General Chat', prompt: '' },
+  { id: 'writer', name: 'Writer', prompt: "You are a skilled writer. Improve, draft, or continue whatever text the user gives you — clear, engaging, and in the user's tone unless asked otherwise. Output only the writing itself, no preamble or explanations." },
+  { id: 'translator', name: 'Translator', prompt: 'You are a professional translator. Translate everything the user says into natural, fluent English (or the target language they name), preserving tone and meaning. Output only the translation.' },
+  { id: 'summarizer', name: 'Summarizer', prompt: 'Summarize whatever the user provides. Lead with the key point, then up to five short bullets. Be faithful to the source; no opinions, no filler.' },
+  { id: 'coder', name: 'Coder', prompt: 'You are an expert programmer. Answer with working code and brief, precise explanations. Prefer minimal, idiomatic solutions; state assumptions in one line.' },
+  { id: 'researcher', name: 'Researcher', prompt: 'You are a research assistant. Answer with verifiable facts, note uncertainty explicitly, and structure longer answers with short headings. Be concise and neutral.' },
+  { id: 'math', name: 'Math', prompt: 'You are a mathematician. Solve what the user asks, show the essential steps compactly, and end with the result on its own line.' },
+  { id: 'email', name: 'Email', prompt: "Turn the user's words into a polished, professional email — greeting, body, sign-off. Keep it brief and courteous. Output only the email text." },
+  { id: 'explainer', name: 'Explainer', prompt: 'Explain the topic simply, as to a curious beginner — plain words, one good analogy, no jargon. Keep it under 200 words unless asked for depth.' },
+];
+
+// Seed config.settings.aiProfiles exactly once (idempotent — an existing array, even emptied or
+// edited by the user, is never touched). Mutates config, returns it.
+function ensureAiProfiles(config) {
+  if (!config) return config;
+  if (!config.settings) config.settings = {};
+  if (!Array.isArray(config.settings.aiProfiles)) {
+    config.settings.aiProfiles = DEFAULT_AI_PROFILES.map(p => Object.assign({}, p));
+  }
+  return config;
+}
+
+// Resolve a profile id against the library. '' / unknown ids fall back to the FIRST profile
+// (General Chat by default), so a deleted profile never breaks a page.
+function resolveAiProfile(settings, id) {
+  const list = (settings && Array.isArray(settings.aiProfiles)) ? settings.aiProfiles : DEFAULT_AI_PROFILES;
+  if (!list.length) return { id: '', name: 'General Chat', prompt: '' };
+  return list.find(p => p && p.id === id) || list[0];
+}
+
 // Whisper near-silence hallucinations to drop (exact whole-utterance match after normalization, so a
 // real sentence that merely contains these words still passes). Mirrors voicepanel-host.js.
 const STT_NOISE_PHRASES = ['thanks for watching'];
@@ -101,4 +136,4 @@ function isSttNoisePhrase(text) {
   return STT_NOISE_PHRASES.includes(norm);
 }
 
-module.exports = { VOICE_APPS, LEGACY_VOICE_APPS, VOICE_DEFAULTS, voiceSettings, resolveVoiceEndpoints, resolveLucidEndpoints, migrateVoiceConfig, isSttNoisePhrase };
+module.exports = { VOICE_APPS, LEGACY_VOICE_APPS, VOICE_DEFAULTS, DEFAULT_AI_PROFILES, ensureAiProfiles, resolveAiProfile, voiceSettings, resolveVoiceEndpoints, resolveLucidEndpoints, migrateVoiceConfig, isSttNoisePhrase };

--- a/app/voicepanel-host.js
+++ b/app/voicepanel-host.js
@@ -22,6 +22,7 @@ const fs = require('fs');
 const path = require('path');
 const speechLib = require('./claudevoice-speech');   // pure: sentence cutter + sanitizer + per-turn WAV pipeline
 const wyoming = require('./claudevoice-wyoming');    // pure: Wyoming STT/TTS protocol client
+const { resolveAiProfile } = require('./voiceConfig'); // pure: AI-profile library lookup (Smart Profiles)
 
 // Whisper hallucinates stock phrases on background noise/near-silence ("thanks for watching" is the
 // classic, from YouTube training data). Exact-phrase blocklist, compared case/punctuation-insensitively --
@@ -220,6 +221,30 @@ function createVoicePanelHost({ appId, storageKey, log, adapter, branding, deps 
     return speechId;
   }
 
+  // The active page's AI profile (Smart Profiles): per-page pick resolved against the global
+  // library; '' or a deleted id falls back to the library's first entry (General Chat).
+  function currentProfile() {
+    const opts = deps.activeServedAppConfig(appId);
+    const settings = (deps.getConfig() || {}).settings;
+    return resolveAiProfile(settings, (opts && opts.options.profilePick) || '');
+  }
+
+  // Panel Profile picker: persist the pick on the page, hand the prompt to the adapter (chat
+  // backends apply it on the next request; claude quietly restarts-with-resume; codex/copilot
+  // prefix their next turn), and tell every subscribed page.
+  function setProfile(id) {
+    if (typeof id !== 'string' || id.length > 64) return false;
+    const g = deps.activeGrid();
+    if (!ownsGrid(g)) return false;
+    if (!g.options) g.options = {};
+    g.options.profilePick = id;
+    deps.saveConfig();
+    const prof = currentProfile();
+    if (adapter.setProfilePrompt) adapter.setProfilePrompt(prof.prompt || '');
+    broadcast({ type: 'profile', id: prof.id, name: prof.name });
+    return true;
+  }
+
   function getState() {
     const opts = deps.activeServedAppConfig(appId);
     return Object.assign({}, state, {
@@ -247,6 +272,9 @@ function createVoicePanelHost({ appId, storageKey, log, adapter, branding, deps 
       approvalAlways: !!adapter.supportsAlwaysApproval,   // "Always" = approve + stop asking this session (codex acceptForSession)
       // Backends without a working directory (owui/api chat) hide the page's folder button.
       hasProject: brand.hasProject !== false,
+      // Smart Profiles: the global library (names only) + this page's current pick.
+      profiles: ((((deps.getConfig() || {}).settings || {}).aiProfiles) || []).map(p => ({ id: p.id, name: p.name })),
+      profile: currentProfile().id,
     };
   }
 
@@ -328,6 +356,7 @@ function createVoicePanelHost({ appId, storageKey, log, adapter, branding, deps 
       mode: opts.options.permissionMode || undefined,
       model: opts.options.modelPick,
       approvalsEnabled: !!opts.options.approvalsEnabled,
+      profilePrompt: currentProfile().prompt || '',
     });
     state = { running: true, status: 'idle', lastUserText: '', lastAssistantText: '', error: null };
     turnActive = false;
@@ -423,6 +452,7 @@ function createVoicePanelHost({ appId, storageKey, log, adapter, branding, deps 
       getProjects,
       setOption,
       setPermissionMode,
+      setProfile,
       setModel: model => adapter.setModel(model),
       sessionStart: startSession,
       sessionStop: stopSession,

--- a/apps/apps.json
+++ b/apps/apps.json
@@ -6244,6 +6244,7 @@
       { "key": "projectDir", "label": "Default folder", "type": "text", "default": "" },
       { "key": "projectsRoot", "label": "Folders root (for the panel picker)", "type": "text", "default": "" },
       { "key": "permissionMode", "label": "Permission mode (choices depend on the backend)", "type": "text", "default": "" },
+      { "key": "profilePick", "label": "AI profile (see Settings → AI Profiles)", "type": "text", "default": "" },
       { "key": "approvalsEnabled", "label": "Touch approval when in Manual mode (Claude Code)", "type": "bool", "default": true },
       { "key": "apiBaseUrl", "label": "API endpoint base URL (OpenAI-compatible)", "type": "text", "default": "https://api.openai.com/v1" },
       { "key": "apiKey", "label": "API endpoint key", "type": "secret", "default": "" },

--- a/apps/apps.json
+++ b/apps/apps.json
@@ -6250,7 +6250,7 @@
       { "key": "apiKey", "label": "API endpoint key", "type": "secret", "default": "" },
       { "key": "apiModel", "label": "API model (e.g. gpt-4o-mini)", "type": "text", "default": "" },
       { "key": "chatFontSize", "label": "Chat text size (px)", "type": "text", "default": "16" },
-      { "key": "vadHangoverMs", "label": "Voice pause tolerance (ms)", "type": "text", "default": "800" },
+      { "key": "vadHangoverMs", "label": "Voice pause tolerance (ms)", "type": "text", "default": "400" },
       { "key": "micDevice", "label": "Microphone (set from the panel Settings)", "type": "text", "default": "" },
       { "key": "spkDevice", "label": "Speaker (set from the panel Settings)", "type": "text", "default": "" },
       { "key": "modelPick", "label": "Model (set from the panel Settings; blank = default)", "type": "text", "default": "" }

--- a/docs/ai-voice.md
+++ b/docs/ai-voice.md
@@ -114,6 +114,19 @@ Toggling the checkbox takes effect the next time a panel session starts. If the 
 unreachable or doesn't respond in time, the request **fails closed** (denied) — never an
 unattended auto-allow.
 
+## Profiles (Smart Profiles)
+
+The **Profile** button switches what the AI *is* for this conversation — a named instruction like
+Translator, Summarizer, Writer, Coder, Math, or Email. Tap it for a full-screen grid of big cards;
+one tap switches. Ships with 9 editable defaults; manage them (rename, rewrite, add, delete) under
+**Settings → AI Profiles**. Each AI Voice page remembers its own current profile, and the editor's
+**Default profile** row sets what a page starts with.
+
+**General Chat** has an empty instruction — plain, unmodified behavior. How a switch lands depends
+on the backend: API and Open WebUI pages apply it instantly mid-conversation; Claude Code quietly
+restarts the session (keeping the conversation, like the Mode button); Codex and Copilot carry it
+into their next message.
+
 ## Models
 
 The panel's **Settings → Model** picker follows the backend: Claude's fixed pick list, Codex and

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -232,3 +232,11 @@ One connection shared by the meeting **Analysis AI** (Meeting tab) and the
 
 The existing per-page [Open WebUI chat widget](ai-chat.md) keeps its own endpoint options and is
 unaffected.
+
+## AI Profiles
+
+The global library behind the [AI Voice](ai-voice.md) app's **Profile** button: each row is a
+name plus the instruction the AI receives for the conversation (Translator, Summarizer, Writer, …).
+Rename, rewrite, add, or remove rows here — changes apply the next time a profile is picked (or a
+session starts). **General Chat** ships with an empty instruction, which means plain, unmodified
+chat. Deleting a profile that a page was using safely falls back to the first one in the list.

--- a/test/apivoiceSession.test.js
+++ b/test/apivoiceSession.test.js
@@ -138,6 +138,41 @@ test('stop clears the session', () => {
   assert.equal(adapter.sendTurn('x'), false);
 });
 
+test('AI profile rides as a system message; switching applies to the next request', () => {
+  const client = makeClient();
+  const { adapter } = makeAdapter(GOOD, client);
+  adapter.start({ profilePrompt: 'You are a translator.' });
+  adapter.sendTurn('Hallo');
+  assert.deepEqual(client.calls[0].payload.messages[0], { role: 'system', content: 'You are a translator.' });
+  assert.deepEqual(client.calls[0].payload.messages[1], { role: 'user', content: 'Hallo' });
+  client.finishWith(cbs => { cbs.onDelta('Hello'); cbs.onDone({ finishReason: 'stop' }); });
+  // Live switch: next request carries the NEW instruction, still exactly one system message.
+  adapter.setProfilePrompt('You are a poet.');
+  adapter.sendTurn('again');
+  const msgs = client.calls[1].payload.messages;
+  assert.deepEqual(msgs[0], { role: 'system', content: 'You are a poet.' });
+  assert.equal(msgs.filter(m => m.role === 'system').length, 1);
+  // Clearing it removes the system message entirely.
+  adapter.setProfilePrompt('');
+  client.finishWith(cbs => cbs.onDone({ finishReason: 'stop' }));
+  adapter.sendTurn('third');
+  assert.equal(client.calls[2].payload.messages.some(m => m.role === 'system'), false);
+});
+
+test('the profile system message survives the history cap', () => {
+  const client = makeClient();
+  const { adapter } = makeAdapter(GOOD, client);
+  adapter.start({ profilePrompt: 'Stay terse.' });
+  for (let i = 0; i < 30; i++) {
+    adapter.sendTurn('turn ' + i);
+    client.finishWith(cbs => { cbs.onDelta('r' + i); cbs.onDone({ finishReason: 'stop' }); });
+  }
+  adapter.sendTurn('last');
+  const msgs = client.calls[client.calls.length - 1].payload.messages;
+  assert.deepEqual(msgs[0], { role: 'system', content: 'Stay terse.' });   // never evicted
+  assert.ok(msgs.length <= 41, 'got ' + msgs.length);                      // 40 history + 1 system
+});
+
 test('deepseek models get thinking disabled; others send no thinking field', () => {
   const client = makeClient();
   const { adapter } = makeAdapter({ apiBaseUrl: 'https://x/v1', apiKey: 'k', apiModel: 'deepseek-v4-flash' }, client);

--- a/test/sysserver.test.js
+++ b/test/sysserver.test.js
@@ -49,6 +49,7 @@ function makeHandlers(sink) {
     sessionStart: dir => { sink.push(['session-start', dir]); return true; },
     sessionStop: () => { sink.push(['session-stop']); return true; },
     setPermissionMode: mode => { sink.push(['mode', mode]); return true; },
+    setProfile: id => { sink.push(['profile', id]); return true; },
     setModel: model => { sink.push(['model', model]); return true; },
     setOption: (key, value) => { sink.push(['option', key, value]); return true; },
     getProjects: () => ({ root: 'r', parent: null, dirs: [], current: '', recents: [] }),
@@ -310,6 +311,15 @@ test('approval tokens do not cross backends', async () => {
   });
   assert.equal(ok.status, 200);
   assert.deepEqual(alphaCalls, [['approval-request', 'Bash']]);
+});
+
+test('profile switch route dispatches per backend', async () => {
+  const r = await postJson('/ai-test/alpha/profile', { id: 'translator' });
+  assert.equal(r.status, 200);
+  assert.deepEqual(alphaCalls, [['profile', 'translator']]);
+  assert.deepEqual(betaCalls, []);
+  const bad = await postJson('/ai-test/alpha/profile', {});
+  assert.deepEqual(await bad.json(), { ok: false });
 });
 
 test('side-effecting backend routes fail closed without same-origin evidence', async () => {

--- a/test/voiceConfig.test.js
+++ b/test/voiceConfig.test.js
@@ -85,6 +85,32 @@ test('old voice app ids migrate to ai-voice with the matching backend', () => {
   assert.equal(cfg.grids[3].options.modelPick, 'llama3');
 });
 
+test('ensureAiProfiles seeds once and never touches user edits', () => {
+  const { ensureAiProfiles, DEFAULT_AI_PROFILES } = require('../app/voiceConfig');
+  const cfg = {};
+  ensureAiProfiles(cfg);
+  assert.equal(cfg.settings.aiProfiles.length, DEFAULT_AI_PROFILES.length);
+  assert.equal(cfg.settings.aiProfiles[0].id, 'chat');
+  assert.equal(cfg.settings.aiProfiles[0].prompt, '');   // General Chat = plain behavior
+  // User edits and deletions survive re-runs.
+  cfg.settings.aiProfiles = [{ id: 'mine', name: 'Mine', prompt: 'be mine' }];
+  ensureAiProfiles(cfg);
+  assert.deepEqual(cfg.settings.aiProfiles, [{ id: 'mine', name: 'Mine', prompt: 'be mine' }]);
+  // Even an emptied list stays empty (a deliberate delete-all is respected).
+  cfg.settings.aiProfiles = [];
+  ensureAiProfiles(cfg);
+  assert.deepEqual(cfg.settings.aiProfiles, []);
+});
+
+test('resolveAiProfile falls back to the first profile for blank or deleted ids', () => {
+  const { resolveAiProfile } = require('../app/voiceConfig');
+  const settings = { aiProfiles: [{ id: 'a', name: 'A', prompt: 'pa' }, { id: 'b', name: 'B', prompt: 'pb' }] };
+  assert.equal(resolveAiProfile(settings, 'b').prompt, 'pb');
+  assert.equal(resolveAiProfile(settings, '').id, 'a');
+  assert.equal(resolveAiProfile(settings, 'gone').id, 'a');
+  assert.equal(resolveAiProfile({ aiProfiles: [] }, 'x').prompt, '');   // emptied library = plain chat
+});
+
 test('id migration never overwrites an existing backend and is idempotent', () => {
   const cfg = { grids: [{ kind: 'app', app: 'claude-voice', options: { backend: 'codex' } }] };
   migrateVoiceConfig(cfg);


### PR DESCRIPTION
DK-Suite's "9 smart profiles" teardown showed the real feature is editable AI instruction modes inside their chat app — this brings that to AI Voice, on all five backends.

- **Library:** `settings.aiProfiles`, seeded once with 9 editable English defaults (General Chat's empty prompt = exactly today's behavior). New **Settings → AI Profiles** tab (name + instruction rows, add/remove). Per-page pick (`profilePick`) + a **Default profile** select in the page options.
- **Panel:** a **Profile** button on the voice page opens a full-screen 3×3 grid of large touch cards (all nine visible at 1920×480, current = filled accent, built to the design system); one tap switches via the new `/profile` route.
- **Per backend:** api/owui — system message prepended per request (instant mid-conversation switch; can't be evicted by the history cap); claude — folded into `--append-system-prompt`, live switch restarts-with-resume exactly like the Mode button; codex/copilot — instruction prefixed to the next turn (protocols have no instructions slot; transcript shows the user's own words).
- **Bonus fix:** the #22 meta-driven hiding of the Project/Mode rail buttons was a silent no-op (no `.hidden` rule matched `.vpBtn`) — one CSS rule fixes it, and Profile hiding uses the same.
- Deleted profiles fall back safely to the first in the list; an emptied library hides the button entirely.
- **Tests: 215/215** (5 new: system-message injection + live switch + cap survival, `/profile` dispatch, seeding idempotence, resolve fallback).

Needs the hardware pass: Translator on the GLM page (instant), profile switch on Claude (quiet restart, conversation kept), Codex/Copilot next-turn pickup, the grid overlay on the physical panel, General Chat unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)