### PR TITLE
Fix mic LED not toggling while the knob ring is set to All Off

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -2044,6 +2044,19 @@ function applyKnobSettings() {
   try { dev.setLedSpeed(L.speed & 0xFF); } catch (e) {}
   try { dev.setLedColor(hue & 0xFF, sat & 0xFF); } catch (e) {}
   if (L.effect) lastRingEffect = L.effect;
+  // "All Off" (effect 0) repaints the matrix dark and can drop the firmware's mic indicator with
+  // it (same latch class as the connect-time re-assert below in whenReady). Re-assert the mic
+  // state after the effect settles so a lit mic LED survives switching the ring off.
+  if ((L.effect & 0xFF) === 0) setTimeout(() => reassertMicLed('ring set to All Off'), 400);
+}
+// The firmware occasionally drops the mic LED (never the audio toggle) when the LED subsystem is
+// asleep or mid-repaint — proven at connect time, and reported again with the ring on "All Off"
+// (effect 0). The workaround mirrors the connect path: wake the panel, then re-send the current
+// mic state so the LED latches. Harmless when the LED already agrees.
+function reassertMicLed(why) {
+  try { dev.screenOn(); } catch (e) {}
+  try { dev.setMic(micState); } catch (e) {}
+  console.log('mic LED re-assert (' + why + '):', micState);
 }
 // ---- ring override (Claude Code voice states) ----
 // A served page signals its state via console.log('OQX_RING::<state>') (caught in index.js, funneled
@@ -2080,7 +2093,13 @@ function clearRingOverride() {
   ringOverrideState = null;
   applyKnobSettings();
 }
-function applyMic(on) { try { dev.setMic(on); } catch (e) {} micState = !!on; refreshTray(); }
+function applyMic(on) {
+  try { dev.setMic(on); } catch (e) {}
+  micState = !!on; refreshTray();
+  // With the ring on "All Off" the LED subsystem can be idle and the single setMic above toggles
+  // the audio but the mic LED never follows — wake it and re-assert (see reassertMicLed).
+  if ((lighting().effect & 0xFF) === 0 && !ringOverrideState) setTimeout(() => reassertMicLed('mic toggle at ring All Off'), 350);
+}
 function toggleMic() { applyMic(!micState); }
 function toggleKnobRing() {
   if (!config.settings) config.settings = {};


### PR DESCRIPTION
Bug: with Settings → Hardware → Knob Ring → Effect = **All Off (ring off)**, toggling the mic changes the audio but the mic LED never follows.

## Diagnosis (static — needs the morning hardware pass to confirm)
The ARIS-68 firmware drives the mic LED itself from the `setMic` command, but the LED only latches while the LED subsystem is awake — **the codebase already proves this class of bug**: the connect-time handler re-asserts `screenOn()` + `setMic()` 2s after connect because "the mic indicator LED only latches once the panel is fully awake" (main.js). With the ring on All Off (RGB-matrix effect 0) the LED subsystem idles the same way, and `applyMic` sent exactly one bare `setMic` — audio toggles, LED drops.

## Fix
A shared `reassertMicLed()` (screenOn + re-send current mic state, logged), fired:
- ~350ms after a mic toggle while the ring effect is 0, and
- ~400ms after applying an All-Off ring config (so a lit mic LED survives switching the ring off).

No behavior change when the ring is on any live effect. 215/215 tests.

## If the hardware pass still shows a dead LED
Then the firmware genuinely can't render the mic indicator during effect 0 (it would be part of the RGB matrix), and the fallback is changing what "All Off" sends — keep the last effect and drive **brightness 0** instead of effect 0. That's a deliberate semantics change I didn't want to make blind overnight; say the word and it's a three-line follow-up.

**Verify:** ring → All Off → toggle mic from the tray: LED follows (watch for "mic LED re-assert" in the log). Then ring back to an effect → mic toggle still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)