### PR TITLE
Parity tracker: AI shortcut panels in progress; their coming-soon list

### DIFF
--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -5,7 +5,7 @@ What the commercial package advertises versus what open-quake ships. Comparison 
 plus their [Kickstarter](https://www.kickstarter.com/projects/decokee/decokee-quake-the-ultimate-desktop-ai-copilot)
 and [AI-copilot](https://www.decokee.com/pages/quake-ai-copilot) pages (as advertised 2026-08),
 cross-checked against a teardown of the installed DK-Suite (v0.4.69, unpacked Electron); the
-open-quake side is current `main` (v0.5.7). This is the running list of what they have that we
+open-quake side is current `main` (v0.5.9). This is the running list of what they have that we
 don't — update it when either side changes.
 
 > open-quake is an independent community project, not affiliated with DECOKEE — see the
@@ -30,13 +30,27 @@ don't — update it when either side changes.
 | 9 Smart Profiles (knob-switchable "modes") | Teardown: their 9 "profiles" are **page layouts** (Discord/MeetAI/SysView/AI Chat/Music/Clock/…) — already open-quake **pages** with the knob selector and per-page hotkeys. The real feature inside their AI Chat — named prompt modes (theirs: 6, Chinese-only) — **shipped as AI Profiles** (PR #23): 9 editable English instruction presets on all five AI Voice backends, switchable from the panel's full-screen Profile picker, remembered per page. |
 | Wallpapers / screensaver ("Vivid" — teardown: a manually-selected crossfading image/video page, **no idle detection**) | **[Screensaver](screensaver.md)** (PR #24): five built-in live-drawn scenes (Waves, Starfield, Lava lamp, Fireflies, Flurry), your own photos (slideshow or scrapbook **collage**) and videos in separate folders, downloadable loops in [community-wallpapers](../community-wallpapers), and — theirs can't — **idle auto-start** (default 30 min) that wakes back to exactly the page you left. |
 
+## 🔨 In development
+
+| Feature | Status |
+|---|---|
+| **AI-generated shortcut panels** (their pitch: hold the knob, say "create a shortcut set for Photoshop masking" — the AI generates a custom control set, no manual macro programming) | **In progress.** Builds on the two halves open-quake already has: AI routing (CLI agents / OWUI / any endpoint, no credits) and pages-as-JSON tile grids with `key`-type shortcut tiles — a "Generate panel with AI" flow: prompt → validated tile JSON → a new page for review. |
+
 ## ❌ Missing (the actual todo)
 
 | Feature | What they advertise | Lift for open-quake |
 |---|---|---|
 | **macOS / Linux support** | Multi-OS: Windows, macOS, Linux | **Large.** The launcher/editor are Electron (portable), but launch/volume/media/loopback-audio/reserved-display code is Windows-specific (README already flags this). Realistic only as a scoped "panel + apps, minus Windows-only extras" port. |
-| **AI-generated shortcut panels** | Hold the knob and say e.g. "create a shortcut set for Photoshop masking" — the AI generates a custom control set for that application, no manual macro programming (Kickstarter/copilot pages) | **Medium — and a natural fit.** OQ already has the two halves: AI routing (CLI agents / OWUI / any endpoint, no credits) and pages-as-JSON tile grids with `key`-type shortcut tiles. The missing piece is a "Generate panel with AI" flow in the editor (and/or by voice on the panel): prompt → validated tile JSON → new page for review. Probably the highest-value item on this list. |
 | **Game voice control** | Mentioned in their showcase | **Unclear scope.** Nearest OQ equivalents: global hotkeys, macros, LucidType. Needs a real definition of what theirs does before it's worth chasing. |
+
+## 🔮 Their "coming soon" list
+
+| They promise | open-quake today |
+|---|---|
+| Discord Game Controls | Workable now with a manual page: key tiles firing Discord's global hotkeys (mute/deafen/overlay). No packaged Discord page yet — easy candidate if demand shows up. |
+| OBS Studio Controls | Same today via OBS global hotkeys on key tiles. The real version would be a page speaking **obs-websocket** (scene switching, stream/record status on the panel) — moderate lift, natural fit. |
+| Themes | **Already shipped**: light/dark/system + savable accent presets driving the panel, apps, and the knob ring — they're promising what open-quake has. |
+| "And more" | Unspecified; this doc tracks claims concrete enough to compare. |
 
 ## Notes
 

--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -5,7 +5,7 @@ What the commercial package advertises versus what open-quake ships. Comparison 
 plus their [Kickstarter](https://www.kickstarter.com/projects/decokee/decokee-quake-the-ultimate-desktop-ai-copilot)
 and [AI-copilot](https://www.decokee.com/pages/quake-ai-copilot) pages (as advertised 2026-08),
 cross-checked against a teardown of the installed DK-Suite (v0.4.69, unpacked Electron); the
-open-quake side is current `main` (v0.5.9). This is the running list of what they have that we
+open-quake side is the current release (v0.5.9). This is the running list of what they have that we
 don't — update it when either side changes.
 
 > open-quake is an independent community project, not affiliated with DECOKEE — see the
@@ -25,6 +25,7 @@ don't — update it when either side changes.
 | OpenClaw integration ("run your favorite OpenClaw tasks with one tap" — via the OpenAI API server-side) | open-quake runs **real agent sessions natively** — Claude Code, Codex, Copilot — with tools, touch approvals, your own plan; no intermediary service. (Their one-tap *saved routines* idea is a genuine gap — see Missing.) |
 | System monitor (real-time CPU/memory/network) | The **System Monitor** app: live CPU, GPU, RAM, disk, network, battery. |
 | Global mic mute (system-level, one tap) | Knob single-click defaults to **mute**; the Meeting app adds per-call mute/video for Zoom and Teams. |
+| AI-generated shortcut panels ("hold the knob, say 'create a shortcut set for Photoshop masking'") | Shipped in v0.5.9: the **Panel Builder** profile — say what you want on your panel and it **builds the page from speech**: validated keystroke tiles (full punctuation-shortcut support), refine or replace by voice, new page lands in the editor for review. Runs on **your own AI backends** — no credits. |
 | Smart home hub (use-case example) | First-class **Home Assistant integration**: entity tiles, real dashboards, MDI icons. |
 | Stock dashboard / expense automation / 3D-printer control (use-case examples) | Web-dashboard pages + shell/macro tiles + HA cover the same ground generically. |
 | LED ring status for recording/translation/AI states | RGB ring is theme-driven and state-driven (listening/thinking/speaking/approval), fully configurable. |
@@ -32,12 +33,6 @@ don't — update it when either side changes.
 | Credit packs / subscriptions | Nothing metered. Costs are only what your own keys/servers cost. |
 | 9 Smart Profiles (knob-switchable "modes") | Teardown: their 9 "profiles" are **page layouts** (Discord/MeetAI/SysView/AI Chat/Music/Clock/…) — already open-quake **pages** with the knob selector and per-page hotkeys. The real feature inside their AI Chat — named prompt modes (theirs: 6, Chinese-only) — **shipped as AI Profiles** (PR #23): 9 editable English instruction presets on all five AI Voice backends, switchable from the panel's full-screen Profile picker, remembered per page. |
 | Wallpapers / screensaver ("Vivid" — teardown: a manually-selected crossfading image/video page, **no idle detection**) | **[Screensaver](screensaver.md)** (PR #24): five built-in live-drawn scenes (Waves, Starfield, Lava lamp, Fireflies, Flurry), your own photos (slideshow or scrapbook **collage**) and videos in separate folders, downloadable loops in [community-wallpapers](../community-wallpapers), and — theirs can't — **idle auto-start** (default 30 min) that wakes back to exactly the page you left. |
-
-## 🔨 In development
-
-| Feature | Status |
-|---|---|
-| **AI-generated shortcut panels** (their pitch: hold the knob, say "create a shortcut set for Photoshop masking" — the AI generates a custom control set, no manual macro programming) | **In progress.** Builds on the two halves open-quake already has: AI routing (CLI agents / OWUI / any endpoint, no credits) and pages-as-JSON tile grids with `key`-type shortcut tiles — a "Generate panel with AI" flow: prompt → validated tile JSON → a new page for review. |
 
 ## ❌ Missing (the actual todo)
 

--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -22,6 +22,9 @@ don't — update it when either side changes.
 | Instant answers | Any of the AI apps; hold the knob and ask. |
 | Drag-and-drop customization / preset app shortcuts | The PC-side editor: tile grids, merged tiles, per-page apps/dashboards, drag-and-drop, hotkeys. |
 | Music player | Music controller: now-playing, transport, app grid, lyrics. |
+| OpenClaw integration ("run your favorite OpenClaw tasks with one tap" — via the OpenAI API server-side) | open-quake runs **real agent sessions natively** — Claude Code, Codex, Copilot — with tools, touch approvals, your own plan; no intermediary service. (Their one-tap *saved routines* idea is a genuine gap — see Missing.) |
+| System monitor (real-time CPU/memory/network) | The **System Monitor** app: live CPU, GPU, RAM, disk, network, battery. |
+| Global mic mute (system-level, one tap) | Knob single-click defaults to **mute**; the Meeting app adds per-call mute/video for Zoom and Teams. |
 | Smart home hub (use-case example) | First-class **Home Assistant integration**: entity tiles, real dashboards, MDI icons. |
 | Stock dashboard / expense automation / 3D-printer control (use-case examples) | Web-dashboard pages + shell/macro tiles + HA cover the same ground generically. |
 | LED ring status for recording/translation/AI states | RGB ring is theme-driven and state-driven (listening/thinking/speaking/approval), fully configurable. |
@@ -41,13 +44,16 @@ don't — update it when either side changes.
 | Feature | What they advertise | Lift for open-quake |
 |---|---|---|
 | **macOS / Linux support** | Multi-OS: Windows, macOS, Linux | **Large.** The launcher/editor are Electron (portable), but launch/volume/media/loopback-audio/reserved-display code is Windows-specific (README already flags this). Realistic only as a scoped "panel + apps, minus Windows-only extras" port. |
+| **Saved AI routines as tiles** | OpenClaw pitch: capture a spoken task, save it, re-run with one tap | **Small — worth doing.** OQ has agent sessions and tiles, but no tile type that sends a saved prompt to an AI Voice backend. Adding one out-does theirs (routines run on a real agent with tools). |
+| **Mid-meeting [Mark] highlights** | Tap Mark during a meeting; the summary extracts the flagged moments | **Small.** OQ records + summarizes but has no highlight-this-moment button feeding the notes. A timestamp list handed to the analysis prompt covers it. |
+| **Custom emoji generation** | Speak to generate custom emoji for chat apps (their OpenAI-API feature) | **Gimmick.** No equivalent; listed for completeness. |
 | **Game voice control** | Mentioned in their showcase | **Unclear scope.** Nearest OQ equivalents: global hotkeys, macros, LucidType. Needs a real definition of what theirs does before it's worth chasing. |
 
 ## 🔮 Their "coming soon" list
 
 | They promise | open-quake today |
 |---|---|
-| Discord Game Controls | Workable now with a manual page: key tiles firing Discord's global hotkeys (mute/deafen/overlay). No packaged Discord page yet — easy candidate if demand shows up. |
+| Discord Game Controls (a Discord panel already exists in DK-Suite's page wheel per teardown; the Kickstarter pitches an always-on overlay) | Workable now with a manual page: key tiles firing Discord's global hotkeys (mute/deafen/overlay). No packaged Discord page yet — easy candidate if demand shows up. |
 | OBS Studio Controls | Same today via OBS global hotkeys on key tiles. The real version would be a page speaking **obs-websocket** (scene switching, stream/record status on the panel) — moderate lift, natural fit. |
 | Themes | **Already shipped**: light/dark/system + savable accent presets driving the panel, apps, and the knob ring — they're promising what open-quake has. |
 | "And more" | Nothing named yet — new items land here as they announce them. |
@@ -55,7 +61,8 @@ don't — update it when either side changes.
 ## Notes
 
 - Their "no cloud subscription required / open-source engine" claim still routes AI through their
-  credit system; open-quake's equivalent stance is stronger in practice (your CLIs, your servers,
-  your keys).
+  credit system — and their Kickstarter AI disclosure names the backend: everything is the OpenAI
+  ChatGPT API, called server-side. open-quake's stance is stronger in practice (your CLIs, your
+  servers, your keys).
 - Hardware-only items (chassis, stand, transparent window, HDMI/USB wiring) are out of scope — both
   sides run the same device.

--- a/docs/dk-suite-parity.md
+++ b/docs/dk-suite-parity.md
@@ -50,7 +50,7 @@ don't — update it when either side changes.
 | Discord Game Controls | Workable now with a manual page: key tiles firing Discord's global hotkeys (mute/deafen/overlay). No packaged Discord page yet — easy candidate if demand shows up. |
 | OBS Studio Controls | Same today via OBS global hotkeys on key tiles. The real version would be a page speaking **obs-websocket** (scene switching, stream/record status on the panel) — moderate lift, natural fit. |
 | Themes | **Already shipped**: light/dark/system + savable accent presets driving the panel, apps, and the knob ring — they're promising what open-quake has. |
-| "And more" | Unspecified; this doc tracks claims concrete enough to compare. |
+| "And more" | Nothing named yet — new items land here as they announce them. |
 
 ## Notes
 


### PR DESCRIPTION
- AI-generated shortcut panels moves Missing → In development.
- New section for DK-Suite's promised features (Discord Game Controls, OBS Studio Controls, Themes, "and more") with open-quake's stance on each — Themes is already shipped; Discord/OBS are workable today via key tiles.
- Header version bumped to v0.5.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)