### PR TITLE
Busy presence: drive a Kuando Busylight, WLED, and Home Assistant from call state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ docs/current-state.md
 # IF player runtime saves (created by server.js save-store at runtime; never source)
 community-apps/if-player/saves/
 X/
+.busy-shots/

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -63,6 +63,26 @@ Zoom/Teams call begins.
   (folder, mic label, auto-record, call-app allowlist, silence-stop minutes, echo gate) —
   global, so auto-record works regardless of the active app.
 
+- **Busy presence (added after Phase 1).** The native monitor's contract CHANGED: it now emits
+  `{"active":…,"app":…,"apps":[…]}`, where `apps` lists EVERY allowlisted process holding a capture
+  session. Windows shared-mode capture lets several apps hold one microphone at once — which is also
+  why the recorder can capture your mic while Teams is in a call.
+
+  Both consumers must filter `apps[]` against their own list. Do NOT read:
+    - `app` — whichever endpoint enumeration reached first, not necessarily a record app. With
+      Discord idling on the mic, a Teams call reports as Discord and auto-record never starts.
+    - the top-level `active` flag — true while ANY watched app holds the mic, so auto-stop keyed off
+      it never fires while Discord sits open, and the recording runs to the silence timer.
+
+  Routing lives in `app/micMonitorRouting.js` (pure, unit-tested). `test/meetingDefaultsSync.test.js`
+  asserts the C# source still honours this contract, because every other test runs on captured strings
+  and cannot detect a reverted helper — which happened once during development and survived a fully
+  green suite.
+
+  Outputs fan out through `app/presenceService.js` to a Kuando Busylight (`app/busylightService.js`,
+  node-hid, verified against a real Omega which enumerates as 0x27BB:**0x3BCF**, not the 0x3BCD every
+  reference documents), a WLED light, and Home Assistant via MQTT discovery (`app/presenceMqtt.js`).
+
 ## Known follow-ups (later phases)
 - Transcription / diarization / analysis pipeline over the recorded WAVs.
 - macOS support (loopback = ScreenCaptureKit perms; the native monitor is Windows-only).

--- a/app/busySchedule.js
+++ b/app/busySchedule.js
@@ -1,0 +1,107 @@
+'use strict';
+// "Only drive the busy light during these hours, on these days."
+//
+// Pure and dependency-free: it answers "is the schedule active at this instant" and "when should I
+// look again", and nothing else. The two things that make schedules wrong are handled here rather
+// than at the call site:
+//
+//   1. OVERNIGHT WINDOWS. 22:00-06:00 is a legitimate window that wraps midnight. Comparing
+//      start <= now < end gets it backwards and the light works only during the hours you excluded.
+//      A window whose end is at or before its start is treated as wrapping.
+//   2. WHICH DAY A WRAPPED WINDOW BELONGS TO. For 22:00-06:00 with Friday ticked, 01:00 on Saturday
+//      is inside Friday's window — the day is the day the window STARTED, not the day it is now.
+//
+// Days are 0=Sunday..6=Saturday, matching Date.getDay().
+
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const DEFAULT_DAYS = '1,2,3,4,5';        // Mon-Fri
+const DEFAULT_START = '08:00';
+const DEFAULT_END = '17:00';
+
+// '08:30' -> 510 minutes. Anything unparseable is null so callers can fall back rather than silently
+// treating a typo as midnight.
+function toMinutes(hhmm) {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(hhmm == null ? '' : hhmm).trim());
+  if (!m) return null;
+  const h = Number(m[1]), mi = Number(m[2]);
+  if (h > 23 || mi > 59) return null;
+  return h * 60 + mi;
+}
+
+function parseDays(csv) {
+  const out = new Set();
+  String(csv == null ? '' : csv).split(/[,\s]+/).forEach(p => {
+    // The empty-string guard is load-bearing: ''.split() yields [''] and Number('') is 0, so without
+    // it an empty day list silently means "Sundays" instead of "no days".
+    if (p === '') return;
+    const n = Number(p);
+    if (Number.isInteger(n) && n >= 0 && n <= 6) out.add(n);
+  });
+  return out;
+}
+
+// The start/end pair in force for a given day: the per-day entry when per-day times are on and that
+// day has one, otherwise the shared pair.
+function windowFor(sched, day) {
+  const s = sched || {};
+  if (s.perDay && s.times && s.times[day]) {
+    const t = s.times[day];
+    const a = toMinutes(t.s), b = toMinutes(t.e);
+    if (a != null && b != null) return { start: a, end: b };
+  }
+  const a = toMinutes(s.start), b = toMinutes(s.end);
+  if (a == null || b == null) return null;
+  return { start: a, end: b };
+}
+
+// Is `date` inside the schedule? A schedule that is disabled, or whose times cannot be parsed, is
+// treated as ALWAYS ACTIVE — a broken schedule must not silently disable the light the user asked
+// for. Failing open is the safer direction here: the worst case is the light shows outside hours,
+// which is visible and fixable, versus a light that mysteriously never comes on.
+function isActive(date, sched) {
+  const s = sched || {};
+  if (!s.enabled) return true;
+  const days = parseDays(s.days);
+  if (days.size === 0) return false;      // an explicit empty day set means "never", not "always"
+
+  const d = date instanceof Date ? date : new Date(date);
+  const nowMin = d.getHours() * 60 + d.getMinutes();
+  const today = d.getDay();
+  const yesterday = (today + 6) % 7;
+
+  // Unparseable times mean no usable window at all -> fail open (see the note above) rather than
+  // leaving the user with a light that never comes on and no clue why.
+  if (!windowFor(s, today) && !windowFor(s, yesterday)) return true;
+
+  // A window that starts today.
+  if (days.has(today)) {
+    const w = windowFor(s, today);
+    if (w) {
+      if (w.end > w.start) { if (nowMin >= w.start && nowMin < w.end) return true; }
+      else if (nowMin >= w.start) return true;          // wrapped: the evening part, today
+    }
+  }
+  // The tail of a wrapped window that started yesterday.
+  if (days.has(yesterday)) {
+    const w = windowFor(s, yesterday);
+    if (w && w.end <= w.start && nowMin < w.end) return true;
+  }
+  return false;
+}
+
+// A human summary for the settings page, so the user can see what they configured without doing the
+// arithmetic themselves.
+function describe(sched) {
+  const s = sched || {};
+  if (!s.enabled) return 'Always active';
+  const days = [...parseDays(s.days)].sort();
+  if (!days.length) return 'No days selected — the light will never come on';
+  const names = days.map(d => DAY_NAMES[d]).join(', ');
+  if (s.perDay) return names + ', times set per day';
+  const a = toMinutes(s.start), b = toMinutes(s.end);
+  if (a == null || b == null) return names + ', times invalid — treated as always active';
+  const wrap = b <= a ? ' (overnight)' : '';
+  return names + ' ' + s.start + '–' + s.end + wrap;
+}
+
+module.exports = { isActive, describe, toMinutes, parseDays, windowFor, DAY_NAMES, DEFAULT_DAYS, DEFAULT_START, DEFAULT_END };

--- a/app/busylightService.js
+++ b/app/busylightService.js
@@ -1,0 +1,184 @@
+'use strict';
+// Kuando Busylight driver, spoken directly over USB HID — no Kuando "Busylight for UC" daemon.
+//
+// IMPORTANT for anyone debugging this: Windows gives one process at a time a usable handle on the
+// device. If Kuando's own software is running it will fight us for it, and the symptom is a light
+// that flickers or ignores us — which reads as an open-quake bug. Their software must be closed.
+//
+// PROTOCOL PROVENANCE — the byte layout below started from a community reference implementation
+// rather than Kuando documentation, and was then VERIFIED against real hardware: a BUSYLIGHT OMEGA
+// (PLENOM A/S, 0x27BB:0x3BCF) showed red, green, blue and off exactly as commanded, from these
+// frames, over the 65-byte report-id-prefixed write path. It is isolated in buildReport() so it
+// stays correctable in one place, but it is no longer guesswork.
+//
+// Frame: 64 protocol bytes, written with a leading report id, so 65 bytes on the wire.
+//   [0]      report id (0)
+//   [1]      0x10  protocol step: jump to step 0, i.e. "show this colour now"
+//   [2]      repeat
+//   [3..5]   red, green, blue (0..255)
+//   [6],[7]  on time, off time in 100ms units — 0 means steady rather than blinking
+//   [8]      tone + volume; 0x80 is the documented-quiet value the reference uses for silence
+//   [57..62] 0xFF,0xFF,0xFF,0xFF,0x06,0x93  fixed tail the device checks
+//   [63]     checksum high byte, [64] checksum low byte — plain sum of bytes [0..62]
+//
+// KEEPALIVE: the device extinguishes itself roughly 30s after the last write. That is a feature, not
+// a nuisance — it means a crashed or killed open-quake cannot leave you showing busy forever. We
+// re-send every 20s to stay comfortably inside it and deliberately do not try to defeat it.
+
+// Match on VENDOR only. This is load-bearing, not tidiness: every reference documents the Omega as
+// product id 0x3BCD, but a real Omega on this desk enumerates as 0x3BCF. Hardcoding the documented
+// product id finds no device at all on actual hardware.
+const KUANDO_VENDOR_ID = 0x27bb;
+const KEEPALIVE_MS = 20000;
+const REPORT_LENGTH = 65;
+const SILENT_TONE = 0x80;
+
+// Pure: no device, no node-hid. Everything protocol-shaped lives here so it is testable.
+// IF THE TEST LIGHT DOES NOTHING on some other Kuando model, start here: try a bare 64-byte write
+// with every index below shifted down by one (drop buf[0]). The 65-byte form is confirmed working on
+// an Omega, so suspect the model before you suspect these offsets.
+function buildReport(color) {
+  const c = color || {};
+  const clamp = v => Math.max(0, Math.min(255, Math.round(Number(v) || 0)));
+  const buf = new Array(REPORT_LENGTH).fill(0);
+  buf[1] = 0x10;
+  buf[3] = clamp(c.r);
+  buf[4] = clamp(c.g);
+  buf[5] = clamp(c.b);
+  buf[6] = 0;              // steady, not blinking
+  buf[7] = 0;
+  buf[8] = SILENT_TONE;
+  buf[57] = 0xff; buf[58] = 0xff; buf[59] = 0xff; buf[60] = 0xff;
+  buf[61] = 0x06; buf[62] = 0x93;
+  // buf[0] is always 0, so summing [0..62] is arithmetically identical to the reference's
+  // slice(0,63) — spelled this way so the range matches the frame description above.
+  let sum = 0;
+  for (let i = 0; i <= 62; i++) sum += buf[i];
+  buf[63] = (sum >> 8) & 0xff;
+  buf[64] = sum & 0xff;
+  return buf;
+}
+
+// '#ff8000' | '#f80' -> {r,g,b}, scaled by brightness percent. Bad input is black rather than a throw:
+// a mistyped colour in settings should show nothing, never crash the presence fan-out.
+function parseColor(hex, brightnessPercent) {
+  const scale = Math.max(0, Math.min(100, Number(brightnessPercent == null ? 100 : brightnessPercent))) / 100;
+  let s = String(hex == null ? '' : hex).trim().replace(/^#/, '');
+  if (s.length === 3) s = s[0] + s[0] + s[1] + s[1] + s[2] + s[2];
+  if (!/^[0-9a-fA-F]{6}$/.test(s)) return { r: 0, g: 0, b: 0 };
+  return {
+    r: Math.round(parseInt(s.slice(0, 2), 16) * scale),
+    g: Math.round(parseInt(s.slice(2, 4), 16) * scale),
+    b: Math.round(parseInt(s.slice(4, 6), 16) * scale),
+  };
+}
+
+// deps.hid is injected so tests can drive the service with a fake; production passes node-hid.
+function createBusylightService(deps) {
+  const d = deps || {};
+  const log = d.log || (() => {});
+  let hid = d.hid || null;
+  let device = null;
+  let deviceLabel = null;
+  let lastColor = { r: 0, g: 0, b: 0 };
+  let keepaliveTimer = null;
+  let lastError = null;
+
+  function loadHid() {
+    if (hid) return hid;
+    // Required lazily: node-hid is a native module, and a machine whose rebuild has not been run
+    // should degrade to "no light" rather than take the whole app down at import time.
+    try { hid = require('node-hid'); } catch (e) { lastError = 'node-hid unavailable: ' + e.message; }
+    return hid;
+  }
+
+  function findDevice() {
+    const h = loadHid();
+    if (!h) return null;
+    try {
+      return (h.devices() || []).find(x => x && x.vendorId === KUANDO_VENDOR_ID) || null;
+    } catch (e) { lastError = e.message; return null; }
+  }
+
+  function open() {
+    if (device) return true;
+    const info = findDevice();
+    if (!info) { lastError = lastError || 'no Kuando Busylight found'; return false; }
+    try {
+      device = hid.HID ? new hid.HID(info.path) : new hid.default.HID(info.path);
+      deviceLabel = info.product || 'Busylight';
+      lastError = null;
+      log('busylight connected: ' + deviceLabel);
+      return true;
+    } catch (e) {
+      // Kuando's own software holding the handle lands here. Say so, because the raw message is
+      // opaque and this is by far the most likely cause.
+      device = null;
+      lastError = 'cannot open Busylight (' + e.message + ') — is Kuando Busylight for UC running?';
+      return false;
+    }
+  }
+
+  function writeReport(color) {
+    if (!device && !open()) return false;
+    try {
+      device.write(buildReport(color));
+      return true;
+    } catch (e) {
+      // Unplugged mid-session, or the handle went stale. Drop it so the next call re-detects rather
+      // than writing to a dead handle forever.
+      lastError = e.message;
+      try { device.close(); } catch (e2) {}
+      device = null;
+      return false;
+    }
+  }
+
+  function startKeepalive() {
+    if (keepaliveTimer) return;
+    keepaliveTimer = setInterval(() => { writeReport(lastColor); }, KEEPALIVE_MS);
+    if (keepaliveTimer.unref) keepaliveTimer.unref();
+  }
+  function stopKeepalive() {
+    if (keepaliveTimer) { clearInterval(keepaliveTimer); keepaliveTimer = null; }
+  }
+
+  return {
+    setColor(color) {
+      lastColor = color || { r: 0, g: 0, b: 0 };
+      const ok = writeReport(lastColor);
+      // INTENTIONAL: keepalive runs only while showing a non-black colour. An all-black keepalive
+      // would hold the device awake forever and defeat its own 30s timeout — which is precisely the
+      // crash failsafe this feature relies on to avoid a stuck-busy light.
+      if (ok && (lastColor.r || lastColor.g || lastColor.b)) startKeepalive(); else stopKeepalive();
+      return ok;
+    },
+    off() {
+      lastColor = { r: 0, g: 0, b: 0 };
+      stopKeepalive();
+      return writeReport(lastColor);
+    },
+    isConnected() { return !!device; },
+    // Cheap enough to call from the editor for a status line; does not open the device.
+    detect() {
+      const info = findDevice();
+      return info ? { found: true, product: info.product || 'Busylight', path: info.path } : { found: false, error: lastError };
+    },
+    status() {
+      return { connected: !!device, product: deviceLabel, error: lastError };
+    },
+    close() {
+      stopKeepalive();
+      if (device) {
+        try { device.write(buildReport({ r: 0, g: 0, b: 0 })); } catch (e) {}
+        try { device.close(); } catch (e) {}
+        device = null;
+      }
+    },
+  };
+}
+
+module.exports = {
+  createBusylightService, buildReport, parseColor,
+  KUANDO_VENDOR_ID, KEEPALIVE_MS, REPORT_LENGTH,
+};

--- a/app/config-preload.js
+++ b/app/config-preload.js
@@ -59,6 +59,10 @@ contextBridge.exposeInMainWorld('openQuakeConfig', {
   getEmojiIndex() { return ipcRenderer.invoke('getEmojiIndex'); },
   refreshHaCache() { return ipcRenderer.invoke('refreshHaCache'); },
   fetchHaEntityState(entityId) { return ipcRenderer.invoke('fetchHaEntityState', entityId); },
+  // Busy status: drive one output on demand from the Test buttons, and read what main can actually
+  // see (is a Busylight attached, is the broker connected) rather than only what the user typed.
+  busyTest(target) { return ipcRenderer.invoke('busyTest', target); },
+  busyStatus() { return ipcRenderer.invoke('busyStatus'); },
   // Claude Code voice app: candidate project directories under the configured projects root (Phase 3).
   listProjectDirs(root) { return ipcRenderer.invoke('listProjectDirs', root); },
   // Claude Code voice app: open the user-customizable panel prompt file in the default editor.

--- a/app/config.js
+++ b/app/config.js
@@ -3771,8 +3771,13 @@
     const th = currentTheme();
     // Meeting recording settings (config.settings.meeting) — global so auto-record works regardless of
     // which app the panel is showing. Same shape as MEETING_DEFAULTS in main.js.
-    const currentMe = () => Object.assign({ folder: '', processedFolder: '', processedByDate: false, transcribeUrl: '', analysisAi: 'claude', micDevice: '', echoGate: false, silenceStopMin: 0, autoRecord: false, recordApps: 'Zoom.exe,Teams.exe,ms-teams.exe', outlookEnabled: false, meetingInfoSource: 'classic', outlookAccount: '', outlookCalendar: 'Calendar', outlookSkipPrefixes: 'Canceled:', transcribeThreshold: '', myName: '', separateRecurring: false, appendMeetingName: false, separateTranscript: false, useDetailsFolder: false, transcribeHooksEnabled: false, preTranscribeCmd: '', postTranscribeCmd: '', taskListEnabled: false, taskListFolder: '', joplinEnabled: false, joplinUrl: '', joplinToken: '', joplinNotebook: 'NW Pipe', slideCaptureEnabled: false, slideAutoStartOnSelect: false, slideNotifications: true, slideHotkeyToggle: 'Ctrl+Alt+S', slideHotkeySelect: 'Ctrl+Alt+W', slideHotkeyManual: 'Ctrl+Alt+C', slideAppFilter: '', slideIdleStopMin: 30, highlightEnabled: false, panelsOpen: '', largeRecordButton: false }, (config.settings || {}).meeting || {});
+    const currentMe = () => Object.assign({ folder: '', processedFolder: '', processedByDate: false, transcribeUrl: '', analysisAi: 'claude', micDevice: '', echoGate: false, silenceStopMin: 0, autoRecord: false, recordApps: 'Zoom.exe,Teams.exe,ms-teams.exe', outlookEnabled: false, meetingInfoSource: 'classic', outlookAccount: '', outlookCalendar: 'Calendar', outlookSkipPrefixes: 'Canceled:', transcribeThreshold: '', myName: '', separateRecurring: false, appendMeetingName: false, separateTranscript: false, useDetailsFolder: false, transcribeHooksEnabled: false, preTranscribeCmd: '', postTranscribeCmd: '', taskListEnabled: false, taskListFolder: '', joplinEnabled: false, joplinUrl: '', joplinToken: '', joplinNotebook: 'NW Pipe', slideCaptureEnabled: false, slideAutoStartOnSelect: false, slideNotifications: true, slideHotkeyToggle: 'Ctrl+Alt+S', slideHotkeySelect: 'Ctrl+Alt+W', slideHotkeyManual: 'Ctrl+Alt+C', slideAppFilter: '', slideIdleStopMin: 30, highlightEnabled: false, panelsOpen: '', largeRecordButton: false, busyEnabled: false, busyApps: 'Zoom.exe,Teams.exe,ms-teams.exe,Webex.exe,slack.exe,Discord.exe', busyOnRecording: true, busyOffDelaySec: 5, busyLightEnabled: false, busyLightBusyColor: '#ff0000', busyLightFreeColor: '#00ff00', busyLightBrightness: 100, busyManualColor: '#a020f0', busyLightFreeOff: false, busySchedEnabled: false, busySchedDays: '1,2,3,4,5', busySchedStart: '08:00', busySchedEnd: '17:00', busySchedPerDay: false, busySchedTimes: {}, busyWledEnabled: false, busyWledHost: '', busyMqttEnabled: false, busyMqttUrl: '', busyMqttUser: '', busyMqttPassword: '', busyMqttBaseTopic: 'open-quake' }, (config.settings || {}).meeting || {});
     const me = currentMe();
+    // Day set for the busylight schedule. Built here so the markup below stays readable; the empty
+    // guard matters because ''.split(',') yields [''] and Number('') is 0, which would silently
+    // pre-tick Sunday for a user who has selected no days at all.
+    const schedDays = new Set(String(me.busySchedDays || '').split(/[,\s]+/)
+      .filter(x => x !== '').map(Number).filter(n => Number.isInteger(n) && n >= 0 && n <= 6));
     // Global TTS/STT (Wyoming) endpoints (config.settings.voice) — same shape as VOICE_DEFAULTS in
     // voiceConfig.js. Each service has its own host+port so STT and TTS can live on different servers.
     const currentVoice = () => Object.assign({ sttHost: '', sttPort: '10300', ttsHost: '', ttsPort: '10200' }, (config.settings || {}).voice || {});
@@ -3980,6 +3985,81 @@
       <div class="row" style="margin-top:12px"><label>Stop after silence</label>
         <input type="number" id="meSilence" min="0" step="1" value="${Number(me.silenceStopMin) || 0}" style="width:90px"> <span class="hint" style="margin:0 0 0 8px">minutes (0 = never)</span></div>
       <p class="hint">Automatically stop a recording after this many minutes with no audio on either channel.</p>
+
+      <p class="sectitle">Busy status</p>
+      <div class="row"><label class="iconopt" style="width:auto"><input type="checkbox" id="meBusy" ${me.busyEnabled ? 'checked' : ''}> Show a busy indicator while you are on a call</label></div>
+      <details class="hint"><summary>Turns a busy light red while an app below has your microphone, and back to free when the call ends — replacing the light vendor's own software.</summary> Uses the same detection as auto-record, so it never triggers on Claude voice or other microphone use. Also publishes your status to Home Assistant if you enable it below.</details>
+      <div id="meBusyDeps"${me.busyEnabled ? '' : ' style="display:none"'}>
+        <div class="row"><label>Call apps</label>
+          <input id="meBusyApps" value="${esc(me.busyApps)}" style="flex:1"></div>
+        <p class="hint">Comma-separated Windows process names that count as being on a call. This list is separate from the auto-record list above — you may want the light for calls you do not record.</p>
+        <div class="row"><label class="iconopt" style="width:auto"><input type="checkbox" id="meBusyRec" ${me.busyOnRecording ? 'checked' : ''}> Also show busy while open-quake is recording</label></div>
+        <div class="row" style="margin-top:12px"><label>Return to free after</label>
+          <input type="number" id="meBusyDelay" min="0" max="120" step="1" value="${Number(me.busyOffDelaySec) || 0}" style="width:90px"> <span class="hint" style="margin:0 0 0 8px">seconds</span></div>
+        <p class="hint">A short delay stops the light flickering when a call app briefly releases the microphone mid-meeting, which Teams does when the meeting window changes.</p>
+
+        <p class="sectitle" style="margin-top:20px">Busy light (USB)</p>
+        <div class="row"><label>Kuando Busylight</label><span id="meBusyLightStatus" class="hint" style="margin:0">Checking…</span></div>
+        <div class="row"><label class="iconopt" style="width:auto"><input type="checkbox" id="meBusyLight" ${me.busyLightEnabled ? 'checked' : ''}> Drive a Kuando Busylight over USB</label></div>
+        <details class="hint"><summary>Talks to the light directly — Kuando's own Busylight for UC software must not be running.</summary> Windows lets only one program hold the device, so if theirs is running the light will appear to flicker or ignore open-quake. Uninstalling or quitting it is the fix.</details>
+        <div class="row"><label>Busy colour</label>
+          <input type="color" id="meBusyColor" value="${esc(me.busyLightBusyColor)}" style="width:64px;padding:2px">
+          <label style="width:auto;margin-left:16px">Free colour</label>
+          <input type="color" id="meFreeColor" value="${esc(me.busyLightFreeColor)}" style="width:64px;padding:2px"></div>
+        <div class="row"><label class="iconopt" style="width:auto"><input type="checkbox" id="meFreeOff" ${me.busyLightFreeOff ? 'checked' : ''}> Turn the light off when free instead of showing the free colour</label></div>
+        <div class="row"><label>Custom colour</label>
+          <input type="color" id="meManualColor" value="${esc(me.busyManualColor)}" style="width:64px;padding:2px">
+          <span class="hint" style="margin:0 0 0 12px">Used by the panel's <b>Custom</b> busy mode; also pickable on the panel.</span></div>
+        <div class="row"><label>Brightness</label>
+          <input type="number" id="meBusyBright" min="1" max="100" step="1" value="${Number(me.busyLightBrightness) || 100}" style="width:90px"> <span class="hint" style="margin:0 0 0 8px">%</span></div>
+        <div class="row"><button id="meBusyTestLight" type="button">Test light</button> <span id="meBusyTestLightResult" class="hint" style="margin:0 0 0 10px"></span></div>
+        <div class="row" style="margin-top:14px"><label class="iconopt" style="width:auto"><input type="checkbox" id="meSched" ${me.busySchedEnabled ? 'checked' : ''}> Busylight schedule</label></div>
+        <details class="hint"><summary>Only drive the Busylight on the days and between the hours you pick.</summary> Outside the schedule the light stays off; the Home Assistant entity and any WLED light keep reporting normally. An end time earlier than the start time means the window runs overnight.</details>
+        <div id="meSchedDeps"${me.busySchedEnabled ? '' : ' style="display:none"'}>
+          <div class="row"><label>Days</label>
+            <span id="meSchedDays" style="display:flex;gap:14px;flex-wrap:wrap">${
+              ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d, i) =>
+                `<label class="iconopt" style="width:auto;gap:5px"><input type="checkbox" data-day="${i}" ${schedDays.has(i) ? 'checked' : ''}> ${d}</label>`).join('')
+            }</span></div>
+          <div class="row"><label class="iconopt" style="width:auto"><input type="checkbox" id="meSchedPerDay" ${me.busySchedPerDay ? 'checked' : ''}> Use different hours for each day</label></div>
+          <div id="meSchedShared"${me.busySchedPerDay ? ' style="display:none"' : ''}>
+            <div class="row"><label>Active from</label>
+              <input type="time" id="meSchedStart" value="${esc(me.busySchedStart)}" style="width:130px">
+              <label style="width:auto;margin-left:16px">to</label>
+              <input type="time" id="meSchedEnd" value="${esc(me.busySchedEnd)}" style="width:130px"></div>
+          </div>
+          <div id="meSchedPerDayRows"${me.busySchedPerDay ? '' : ' style="display:none"'}>${
+            ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d, i) => schedDays.has(i)
+              ? `<div class="row"><label>${d}</label>
+                   <input type="time" data-daystart="${i}" value="${esc((me.busySchedTimes[i] || {}).s || me.busySchedStart)}" style="width:130px">
+                   <label style="width:auto;margin-left:16px">to</label>
+                   <input type="time" data-dayend="${i}" value="${esc((me.busySchedTimes[i] || {}).e || me.busySchedEnd)}" style="width:130px"></div>`
+              : '').join('')
+          }</div>
+          <p class="hint" id="meSchedSummary"></p>
+        </div>
+
+        <p class="sectitle" style="margin-top:20px">DIY light (WLED)</p>
+        <div class="row"><label class="iconopt" style="width:auto"><input type="checkbox" id="meWled" ${me.busyWledEnabled ? 'checked' : ''}> Drive a WLED light over the network</label></div>
+        <div class="row"><label>Address</label>
+          <input id="meWledHost" value="${esc(me.busyWledHost)}" placeholder="192.168.1.50" style="flex:1"></div>
+        <p class="hint">The ESP32's IP address or hostname. Uses the same busy and free colours as the USB light.</p>
+        <div class="row"><button id="meBusyTestWled" type="button">Test light</button> <span id="meBusyTestWledResult" class="hint" style="margin:0 0 0 10px"></span></div>
+
+        <p class="sectitle" style="margin-top:20px">Home Assistant (MQTT)</p>
+        <div class="row"><label>Broker</label><span id="meMqttStatus" class="hint" style="margin:0">Not configured</span></div>
+        <div class="row"><label class="iconopt" style="width:auto"><input type="checkbox" id="meMqtt" ${me.busyMqttEnabled ? 'checked' : ''}> Publish your busy status to Home Assistant</label></div>
+        <details class="hint"><summary>Creates a <b>binary_sensor.open_quake_busy</b> entity in Home Assistant automatically — no configuration needed on the Home Assistant side.</summary> Automations can trigger on it like any other sensor. If open-quake stops or the PC loses power, the entity goes <i>unavailable</i> on its own, so a light driven from it cannot get stuck showing busy. This is separate from the Home Assistant connection on the Auth tab, which is read-only.</details>
+        <div class="row"><label>Broker URL</label>
+          <input id="meMqttUrl" value="${esc(me.busyMqttUrl)}" placeholder="mqtt://192.168.1.25:1883" style="flex:1"></div>
+        <div class="row"><label>Username</label>
+          <input id="meMqttUser" value="${esc(me.busyMqttUser)}" style="flex:1"></div>
+        <div class="row"><label>Password</label>${secretInput(me.busyMqttPassword, 'id="meMqttPass" style="flex:1"', 'flex:1')}</div>
+        <p class="hint">Stored encrypted at rest. Leave both blank if your broker allows anonymous connections.</p>
+        <div class="row"><label>Topic prefix</label>
+          <input id="meMqttTopic" value="${esc(me.busyMqttBaseTopic)}" placeholder="open-quake" style="flex:1"></div>
+        <div class="row"><button id="meBusyTestMqtt" type="button">Test connection</button> <span id="meBusyTestMqttResult" class="hint" style="margin:0 0 0 10px"></span></div>
+      </div>
 
       <p class="sectitle">Capture</p>
       <div class="row"><label class="iconopt" style="width:auto"><input type="checkbox" id="meEcho" ${me.echoGate ? 'checked' : ''}> Echo-gate your microphone</label></div>
@@ -5221,6 +5301,137 @@
       };
       document.getElementById('meTransUrl').oninput = e => saveMe({ transcribeUrl: e.target.value.trim() });
       document.getElementById('meAnalysisAi').onchange = e => saveMe({ analysisAi: e.target.value });
+      // --- Busy status ---
+      const busyDeps = document.getElementById('meBusyDeps');
+      const syncBusyEnabled = on => { if (busyDeps) busyDeps.style.display = on ? '' : 'none'; };
+      document.getElementById('meBusy').onchange = e => { saveMe({ busyEnabled: e.target.checked }); syncBusyEnabled(e.target.checked); };
+      document.getElementById('meBusyApps').oninput = e => saveMe({ busyApps: e.target.value });
+      document.getElementById('meBusyRec').onchange = e => saveMe({ busyOnRecording: e.target.checked });
+      document.getElementById('meBusyDelay').oninput = e => saveMe({ busyOffDelaySec: Math.max(0, parseInt(e.target.value, 10) || 0) });
+      document.getElementById('meBusyLight').onchange = e => saveMe({ busyLightEnabled: e.target.checked });
+      document.getElementById('meBusyColor').oninput = e => saveMe({ busyLightBusyColor: e.target.value });
+      document.getElementById('meFreeColor').oninput = e => saveMe({ busyLightFreeColor: e.target.value });
+      document.getElementById('meFreeOff').onchange = e => saveMe({ busyLightFreeOff: e.target.checked });
+      document.getElementById('meManualColor').oninput = e => saveMe({ busyManualColor: e.target.value });
+
+      // --- Busylight schedule ---
+      // Re-rendering the whole tab on every change would steal focus mid-edit, so the per-day rows
+      // are rebuilt in place from the current day set instead.
+      const schedDeps = document.getElementById('meSchedDeps');
+      const schedShared = document.getElementById('meSchedShared');
+      const schedRows = document.getElementById('meSchedPerDayRows');
+      const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+      const readSchedDays = () => Array.from(document.querySelectorAll('#meSchedDays input[data-day]'))
+        .filter(c => c.checked).map(c => Number(c.dataset.day)).sort((a, b) => a - b);
+
+      const readSchedTimes = () => {
+        const out = {};
+        document.querySelectorAll('#meSchedPerDayRows input[data-daystart]').forEach(inp => {
+          const d = inp.dataset.daystart;
+          const end = document.querySelector('#meSchedPerDayRows input[data-dayend="' + d + '"]');
+          out[d] = { s: inp.value, e: end ? end.value : '' };
+        });
+        return out;
+      };
+
+      const renderSchedSummary = () => {
+        const el = document.getElementById('meSchedSummary'); if (!el) return;
+        const m = currentMe();
+        if (!m.busySchedEnabled) { el.textContent = ''; return; }
+        const days = readSchedDays();
+        if (!days.length) { el.textContent = 'No days selected — the light will never come on.'; return; }
+        const names = days.map(d => DAY_LABELS[d]).join(', ');
+        if (m.busySchedPerDay) { el.textContent = names + ', with hours set per day.'; return; }
+        const overnight = m.busySchedEnd <= m.busySchedStart ? ' (runs overnight)' : '';
+        el.textContent = names + ', ' + m.busySchedStart + ' to ' + m.busySchedEnd + overnight + '.';
+      };
+
+      const renderPerDayRows = () => {
+        if (!schedRows) return;
+        const m = currentMe();
+        const times = m.busySchedTimes || {};
+        schedRows.innerHTML = readSchedDays().map(i =>
+          '<div class="row"><label>' + DAY_LABELS[i] + '</label>'
+          + '<input type="time" data-daystart="' + i + '" value="' + esc((times[i] || {}).s || m.busySchedStart) + '" style="width:130px">'
+          + '<label style="width:auto;margin-left:16px">to</label>'
+          + '<input type="time" data-dayend="' + i + '" value="' + esc((times[i] || {}).e || m.busySchedEnd) + '" style="width:130px"></div>').join('');
+        schedRows.querySelectorAll('input[type=time]').forEach(inp => {
+          inp.oninput = () => { saveMe({ busySchedTimes: readSchedTimes() }); };
+        });
+      };
+
+      document.getElementById('meSched').onchange = e => {
+        saveMe({ busySchedEnabled: e.target.checked });
+        if (schedDeps) schedDeps.style.display = e.target.checked ? '' : 'none';
+        renderSchedSummary();
+      };
+      document.querySelectorAll('#meSchedDays input[data-day]').forEach(cb => {
+        cb.onchange = () => {
+          saveMe({ busySchedDays: readSchedDays().join(',') });
+          renderPerDayRows();          // a newly ticked day needs its own time row
+          saveMe({ busySchedTimes: readSchedTimes() });
+          renderSchedSummary();
+        };
+      });
+      document.getElementById('meSchedPerDay').onchange = e => {
+        saveMe({ busySchedPerDay: e.target.checked });
+        if (schedShared) schedShared.style.display = e.target.checked ? 'none' : '';
+        if (schedRows) schedRows.style.display = e.target.checked ? '' : 'none';
+        if (e.target.checked) { renderPerDayRows(); saveMe({ busySchedTimes: readSchedTimes() }); }
+        renderSchedSummary();
+      };
+      document.getElementById('meSchedStart').oninput = e => { saveMe({ busySchedStart: e.target.value }); renderSchedSummary(); };
+      document.getElementById('meSchedEnd').oninput = e => { saveMe({ busySchedEnd: e.target.value }); renderSchedSummary(); };
+      renderPerDayRows();
+      renderSchedSummary();
+      document.getElementById('meBusyBright').oninput = e => saveMe({ busyLightBrightness: Math.min(100, Math.max(1, parseInt(e.target.value, 10) || 100)) });
+      document.getElementById('meWled').onchange = e => saveMe({ busyWledEnabled: e.target.checked });
+      document.getElementById('meWledHost').oninput = e => saveMe({ busyWledHost: e.target.value });
+      document.getElementById('meMqtt').onchange = e => saveMe({ busyMqttEnabled: e.target.checked });
+      document.getElementById('meMqttUrl').oninput = e => saveMe({ busyMqttUrl: e.target.value });
+      document.getElementById('meMqttUser').oninput = e => saveMe({ busyMqttUser: e.target.value });
+      document.getElementById('meMqttPass').oninput = e => saveMe({ busyMqttPassword: e.target.value });
+      document.getElementById('meMqttTopic').oninput = e => saveMe({ busyMqttBaseTopic: e.target.value });
+
+      // Test buttons drive one output directly. They save first, because testing a value the user has
+      // typed but not saved would silently test the OLD value and report a misleading result.
+      const busyTest = (target, btnId, outId) => {
+        const btn = document.getElementById(btnId); if (!btn) return;
+        btn.onclick = async () => {
+          const out = document.getElementById(outId);
+          btn.disabled = true; if (out) out.textContent = 'Testing…';
+          try {
+            if (!await doSave()) { if (out) out.textContent = 'Save failed — not tested'; return; }
+            const r = await configApi.busyTest(target);
+            if (out) out.textContent = r && r.ok ? 'OK' : ('Failed: ' + ((r && (r.error || r.status)) || 'no response'));
+          } catch (err) { if (out) out.textContent = 'Failed: ' + (err && err.message ? err.message : String(err)); }
+          finally { btn.disabled = false; }
+        };
+      };
+      busyTest('light', 'meBusyTestLight', 'meBusyTestLightResult');
+      busyTest('wled', 'meBusyTestWled', 'meBusyTestWledResult');
+      busyTest('mqtt', 'meBusyTestMqtt', 'meBusyTestMqttResult');
+
+      // Live status lines, so the page says what it can actually see rather than only what is typed.
+      (async () => {
+        try {
+          const st = await configApi.busyStatus();
+          const light = document.getElementById('meBusyLightStatus');
+          if (light) {
+            const l = st && st.outputs && st.outputs.light;
+            light.textContent = l && l.connected ? ('Connected — ' + (l.product || 'Busylight'))
+              : (l && l.error ? l.error : 'Not detected');
+          }
+          const mq = document.getElementById('meMqttStatus');
+          if (mq) {
+            const m = st && st.outputs && st.outputs.mqtt;
+            mq.textContent = !m || !m.enabled ? 'Not configured'
+              : (m.connected ? 'Connected' : (m.error ? 'Error: ' + m.error : 'Connecting…'));
+          }
+        } catch (e) {}
+      })();
+
       document.getElementById('meAuto').onchange = e => { saveMe({ autoRecord: e.target.checked }); const deps = document.getElementById('meAutoDeps'); if (deps) deps.style.display = e.target.checked ? '' : 'none'; };
       document.getElementById('meApps').oninput = e => saveMe({ recordApps: e.target.value });
       document.getElementById('meSilence').onchange = e => saveMe({ silenceStopMin: Math.max(0, parseInt(e.target.value, 10) || 0) });

--- a/app/main.js
+++ b/app/main.js
@@ -194,6 +194,8 @@ const appRepo = require('./appRepo');                            // pure helpers
 const { safeAppEntry, appEntryUrlPath, safeEditorDeclaration } = require('./dropInPaths'); // contained drop-in manifest paths + editor declaration
 const { knobDefaultFor, parseCustomRing } = require('./knobRouting');   // generic drop-in knob capability
 const claudeVoiceApprovals = require('./claudevoice-approvals'); // required directly ONLY for the boot-time leftover-hook sweep below
+const { createPresenceService } = require('./presenceService');           // busy light / HA presence fan-out
+const { parseAppList, monitorAllowlist, routeMonitorMessage } = require('./micMonitorRouting');
 
 const USER_DIR = app.getPath('userData');
 const CONFIG_PATH = path.join(USER_DIR, 'config.json');                  // writable — works inside a packaged app too
@@ -209,6 +211,7 @@ const THEME_DEFAULT = { appearance: 'system', accent: '#7CFFB2', presets: ['#7CF
 const DEFAULT_SETTINGS = { launchMode: 'editor', micOnLaunch: false, reservedDisplay: false, lighting: Object.assign({}, LED_DEFAULT), theme: Object.assign({}, THEME_DEFAULT) };
 const actionDeps = { fs, shell, exec, execFile, spawn, platform: process.platform, log: message => console.log(message) };
 const mediaKeys = createMediaKeys({ log: message => console.log(message) });
+let presenceService = null;   // busy-presence fan-out (Busylight / WLED / HA over MQTT); null until boot
 let firstRun = false;     // set by loadConfig when there was no prior config (fresh install)
 let micState = false;     // current device mic state (LED follows it)
 let lastDeviceState = {};  // cached from the connector's 'state' events (firmware/luminance/mic) for the diagnostics page
@@ -1996,7 +1999,7 @@ async function onMeetingActionRequest(platform, action) {
 // Settings live under config.settings.meeting (global, like config.settings.monitor) so auto-record
 // works regardless of which app the panel is showing — the meeting page's per-grid options only
 // exist while it's the active app, which is useless for background recording.
-const MEETING_DEFAULTS = { folder: '', processedFolder: '', processedByDate: false, transcribeUrl: '', analysisAi: 'claude', micDevice: '', echoGate: false, silenceStopMin: 0, autoRecord: false, recordApps: 'Zoom.exe,Teams.exe,ms-teams.exe', outlookEnabled: false, meetingInfoSource: 'classic', outlookAccount: '', outlookCalendar: 'Calendar', outlookSkipPrefixes: 'Canceled:', transcribeThreshold: '', myName: '', separateRecurring: false, appendMeetingName: false, separateTranscript: false, useDetailsFolder: false, transcribeHooksEnabled: false, preTranscribeCmd: '', postTranscribeCmd: '', taskListEnabled: false, taskListFolder: '', joplinEnabled: false, joplinUrl: '', joplinToken: '', joplinNotebook: 'NW Pipe', slideCaptureEnabled: false, slideAutoStartOnSelect: false, slideNotifications: true, slideHotkeyToggle: 'Ctrl+Alt+S', slideHotkeySelect: 'Ctrl+Alt+W', slideHotkeyManual: 'Ctrl+Alt+C', slideAppFilter: '', slideIdleStopMin: 30, highlightEnabled: false, panelsOpen: '', largeRecordButton: false };
+const MEETING_DEFAULTS = { folder: '', processedFolder: '', processedByDate: false, transcribeUrl: '', analysisAi: 'claude', micDevice: '', echoGate: false, silenceStopMin: 0, autoRecord: false, recordApps: 'Zoom.exe,Teams.exe,ms-teams.exe', outlookEnabled: false, meetingInfoSource: 'classic', outlookAccount: '', outlookCalendar: 'Calendar', outlookSkipPrefixes: 'Canceled:', transcribeThreshold: '', myName: '', separateRecurring: false, appendMeetingName: false, separateTranscript: false, useDetailsFolder: false, transcribeHooksEnabled: false, preTranscribeCmd: '', postTranscribeCmd: '', taskListEnabled: false, taskListFolder: '', joplinEnabled: false, joplinUrl: '', joplinToken: '', joplinNotebook: 'NW Pipe', slideCaptureEnabled: false, slideAutoStartOnSelect: false, slideNotifications: true, slideHotkeyToggle: 'Ctrl+Alt+S', slideHotkeySelect: 'Ctrl+Alt+W', slideHotkeyManual: 'Ctrl+Alt+C', slideAppFilter: '', slideIdleStopMin: 30, highlightEnabled: false, panelsOpen: '', largeRecordButton: false, busyEnabled: false, busyApps: 'Zoom.exe,Teams.exe,ms-teams.exe,Webex.exe,slack.exe,Discord.exe', busyOnRecording: true, busyOffDelaySec: 5, busyLightEnabled: false, busyLightBusyColor: '#ff0000', busyLightFreeColor: '#00ff00', busyLightBrightness: 100, busyManualColor: '#a020f0', busyLightFreeOff: false, busySchedEnabled: false, busySchedDays: '1,2,3,4,5', busySchedStart: '08:00', busySchedEnd: '17:00', busySchedPerDay: false, busySchedTimes: {}, busyWledEnabled: false, busyWledHost: '', busyMqttEnabled: false, busyMqttUrl: '', busyMqttUser: '', busyMqttPassword: '', busyMqttBaseTopic: 'open-quake' };
 function meetingSettings() { return Object.assign({}, MEETING_DEFAULTS, (config.settings || {}).meeting || {}); }
 // Open WebUI connection (config.settings.owui, edited on the Auth tab): shared by the meeting
 // Analysis-AI backend and the owui-voice panel app. apiKey is a secret — encrypted at rest by
@@ -2225,7 +2228,8 @@ function meetingStateForPanel() {
   st.slide = slideCapture ? slideCapture.getState() : { enabled: false };   // drives the slide-capture column
   st.highlight = meetingHighlights ? meetingHighlights.getState() : { enabled: false };   // drives the highlight column
   st.panelsOpen = m.panelsOpen || '';   // which utility columns to restore on page load
-  st.largeRecord = !!m.largeRecordButton;   // show the big Record button beside Hang Up
+  st.largeRecord = !!m.largeRecordButton;   // show the big Record button
+  st.busy = presenceService ? presenceService.getState() : { enabled: false };   // drives the busy column beside Hang Up
   return st;
 }
 // Panel remote for mid-meeting highlights (start/stop/cancel), reached over HTTP via sysserver.
@@ -2254,12 +2258,31 @@ function onMeetingRecordRequest(cmd, arg) {
   if (cmd === 'state') return { ok: true, state: meetingStateForPanel() };
   if (cmd === 'setMic') { setMeetingMic(arg); return { ok: true, state: meetingStateForPanel() }; }
   if (cmd === 'setPanels') { setMeetingPanels(arg); return { ok: true, state: meetingStateForPanel() }; }
+  // Manual busy override from the meeting panel's Busy column: 'auto' | 'busy' | 'free'.
+  if (cmd === 'busyOverride') {
+    if (!presenceService) return { ok: false, error: 'presence unavailable' };
+    presenceService.setOverride(arg);
+    return { ok: true, state: meetingStateForPanel() };
+  }
+  // Colour for the manual override, picked on the panel. Validated here rather than trusted: this
+  // arrives over HTTP and ends up in the config file and in a device write.
+  if (cmd === 'busyColor') {
+    if (!presenceService) return { ok: false, error: 'presence unavailable' };
+    const hex = String(arg || '').trim();
+    if (!/^#[0-9a-fA-F]{6}$/.test(hex)) return { ok: false, error: 'expected #rrggbb' };
+    if (!config.settings) config.settings = {};
+    if (!config.settings.meeting) config.settings.meeting = {};
+    config.settings.meeting.busyManualColor = hex;
+    presenceService.setManualColor(hex);      // apply now; the light changes under the user's finger
+    saveConfig();                             // and persist, so it survives a restart
+    return { ok: true, state: meetingStateForPanel() };
+  }
   return { ok: false, error: 'unknown record command: ' + cmd };
 }
 // Which utility columns the meeting page has open, remembered across app restarts. It can't live in
 // the page's localStorage: the panel server binds an ephemeral port (listen(0)), so the origin —
 // and with it any web storage — is new on every launch.
-const PANEL_KEYS = ['ctl', 'slide', 'hl'];
+const PANEL_KEYS = ['ctl', 'slide', 'hl', 'busy'];
 function setMeetingPanels(csv) {
   const open = String(csv || '').split(',').map(s => s.trim()).filter(s => PANEL_KEYS.includes(s));
   if (!config.settings) config.settings = {};
@@ -2412,7 +2435,16 @@ function startMicMonitor() {
   if (process.platform !== 'win32') return;
   stopMicMonitor();
   if (!fs.existsSync(MIC_MONITOR_EXE)) { console.log('[meeting] mic-session-monitor.exe missing — auto-record disabled (manual still works)'); return; }
-  const allow = meetingSettings().recordApps || MEETING_DEFAULTS.recordApps;
+  // One monitor serves two consumers with different app lists. Windows shared-mode capture lets
+  // several apps hold the mic at once, so the monitor reports EVERY match and each consumer filters
+  // apps[] against its own list — see app/micMonitorRouting.js for why reading msg.app instead
+  // silently breaks auto-record.
+  const mset = meetingSettings();
+  const recordApps = mset.recordApps || MEETING_DEFAULTS.recordApps;
+  const busyOn = !!mset.busyEnabled;
+  const allow = monitorAllowlist(recordApps, mset.busyApps, busyOn);   // identical to recordApps when busy is off
+  const recordSet = parseAppList(recordApps);
+  const busySet = parseAppList(busyOn ? mset.busyApps : '');
   try {
     micMonitorProc = spawn(MIC_MONITOR_EXE, [allow], { stdio: ['ignore', 'pipe', 'ignore'] });
   } catch (e) { console.log('[meeting] mic monitor spawn failed:', e.message); micMonitorProc = null; return; }
@@ -2426,13 +2458,21 @@ function startMicMonitor() {
       if (!line) continue;
       let msg; try { msg = JSON.parse(line); } catch (e) { continue; }
       const wasFirst = firstLine; firstLine = false;
-      if (!meetingRecorder) continue;
+      const routed = routeMonitorMessage(msg, recordSet, busySet);
       // That opening announcement is a baseline, not a transition. Treating an idle baseline as
       // "the call ended" stopped recordings mid-meeting and split them into a second file every
       // time the monitor was respawned. Only a later idle is a real call-ended.
       if (wasFirst && !msg.active) continue;
-      if (msg.active) meetingRecorder.autoStart(msg.app || null);
-      else meetingRecorder.autoStop('call-ended');
+      // Deliberately keyed off routed.recordApp, NOT msg.active: with a shared allowlist that flag is
+      // true while ANY watched app holds the mic, so a Discord session idling in the background would
+      // keep it true forever and a Teams call ending would never auto-stop the recording.
+      if (meetingRecorder) {
+        if (routed.recordApp) meetingRecorder.autoStart(routed.recordApp);
+        else meetingRecorder.autoStop('call-ended');
+      }
+      if (presenceService) {
+        presenceService.setCall(routed.busyActive, routed.busyActive ? (routed.recordApp || routed.apps[0] || null) : null);
+      }
     }
   });
   micMonitorProc.on('exit', () => { micMonitorProc = null; });
@@ -3558,6 +3598,7 @@ app.whenReady().then(async () => {
             // edge auto-closes + writes the sidecar. Synchronous, so it lands before the stream-close
             // callback renames that sidecar in appendMeetingNameToRecording.
             if (meetingHighlights) { try { meetingHighlights.onRecordingState(st); } catch (e) {} }
+            if (presenceService) { try { presenceService.setRecording(!!st.recording); } catch (e) {} }
             wasRecording = !!st.recording;
           };
         })(),
@@ -3571,6 +3612,12 @@ app.whenReady().then(async () => {
         log: msg => console.log('[meeting] ' + msg),
       });
       meetingRecorder.ensureWindow();   // arm the hidden window so a call can start recording instantly
+      // Built BEFORE the monitor starts, so the very first call transition has somewhere to go.
+      // Guarded on its own: a broken light or an unreachable broker must never cost us the recorder.
+      try {
+        presenceService = createPresenceService({ log: msg => console.log('[busy] ' + msg) });
+        presenceService.applySettings(meetingSettings());
+      } catch (e) { console.log('[busy] presence unavailable: ' + e.message); presenceService = null; }
       startMicMonitor();
     } catch (e) { reportBootFailure('the meeting recorder', e); try { stopMicMonitor(); } catch (er) {} disposeStage(meetingRecorder); meetingRecorder = null; }
 
@@ -3882,6 +3929,19 @@ app.whenReady().then(async () => {
     if (st.connected) { try { st.login = await githubService.accountLogin(); } catch (er) {} }
     return st;
   });
+  // Editor-only, like every handler around it: isFrom() keeps a drop-in page or a served app from
+  // reaching hardware. busyTest drives one output for a couple of seconds and then restores whatever
+  // the real presence state is, so pressing Test during a call cannot leave the light lying.
+  ipcMain.handle('busyTest', async (e, target) => {
+    if (!isFrom(e, configWin)) return { ok: false, error: 'unauthorized' };
+    if (!presenceService) return { ok: false, error: 'busy status is unavailable' };
+    try { return await presenceService.test(String(target || '')); }
+    catch (err) { return { ok: false, error: err.message }; }
+  });
+  ipcMain.handle('busyStatus', async e => {
+    if (!isFrom(e, configWin)) return { ok: false, error: 'unauthorized' };
+    return presenceService ? presenceService.getState() : { enabled: false };
+  });
   ipcMain.handle('connectGitHub', async e => isFrom(e, configWin) ? githubService.connect() : { ok: false, error: 'unauthorized' });
   ipcMain.handle('pollGitHubConnect', async e => {
     if (!isFrom(e, configWin)) return { ok: false, error: 'unauthorized' };
@@ -4099,7 +4159,12 @@ app.whenReady().then(async () => {
     // state, and setMic tears down and re-acquires the capture. Saving unrelated settings (slide
     // capture, theme, anything) must not do either, so they fire only on a real change.
     const nextMeeting = meetingSettings();
-    if (nextMeeting.recordApps !== prevMeeting.recordApps) startMicMonitor();   // re-arm with an edited app allowlist
+    // Re-arm on EITHER list: the monitor now watches the union of record apps and busy apps, so an
+    // edit to the busy list changes its argv too, as does toggling the feature on or off.
+    if (nextMeeting.recordApps !== prevMeeting.recordApps
+      || nextMeeting.busyApps !== prevMeeting.busyApps
+      || !!nextMeeting.busyEnabled !== !!prevMeeting.busyEnabled) startMicMonitor();
+    if (presenceService) { try { presenceService.applySettings(nextMeeting); } catch (e) { console.log('[busy] applySettings: ' + e.message); } }
     if (meetingRecorder && nextMeeting.micDevice !== prevMeeting.micDevice) {
       meetingRecorder.setMic(nextMeeting.micDevice);                            // push an edited mic to the recorder
     }
@@ -4379,6 +4444,7 @@ app.on('before-quit', () => {
   try { dev.stop(); } catch (e) {}                       // close HID devices + clear keep-alive/rescan timers — an open node-hid handle blocks process exit (Cmd+Q would hang -> force-quit)
   try { oauthHandler.stop(); } catch (e) {}              // stop OAuth callback server + background refresh timers
   try { stopMicMonitor(); } catch (e) {}                 // terminate the native mic-in-use monitor child
+  try { if (presenceService) presenceService.stop(); } catch (e) {}      // clear the busy light now rather than waiting for its 30s timeout, and tell HA we are gone
   try { if (meetingRecorder) meetingRecorder.dispose(); } catch (e) {}   // stop any recording + destroy the hidden capture window
   try { if (slideCapture) slideCapture.dispose(); } catch (e) {}         // destroy the hidden slide-capture window
   try { if (sysserver) sysserver.stop(); } catch (e) {}  // stop metrics timers + close the local server

--- a/app/meetingview.html
+++ b/app/meetingview.html
@@ -129,6 +129,49 @@
   .sstat b { color:var(--accent); font-variant-numeric:tabular-nums; }
   .sstat.warn { color:var(--danger); }
 
+  /* ---- busy column ----
+     Shape follows the Highlight column and docs/design-system.md: ONE primary control that IS the
+     state (no separate readout restating it), with secondary rows disclosed only when they apply.
+     Sizes come from the quake-touch-ui table: 112px primary console control, 64px standard rows,
+     26px state word, 18px action text, 15px non-critical status. */
+  #busy { display:none; flex:0 0 260px; background:var(--surf2); border-radius:18px; padding:18px; flex-direction:column; gap:14px; }
+  body.busyon.pbusy #busy { display:flex; }
+  /* The state IS the button. Tapping forces the opposite; colour and text change, geometry never
+     does, so the control stays pixel-stable across every state. */
+  .bbig { height:112px; border-radius:14px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:6px;
+    background:var(--ok,#2f8f5b); color:#04121f; width:100%; transition:background 180ms ease; }
+  .bbig .bword { font-size:26px; font-weight:800; letter-spacing:.5px; }
+  .bbig .bwhy { font-size:18px; font-weight:600; opacity:.8; text-align:center; padding:0 10px;
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:100%; }
+  body.isbusy .bbig { background:var(--danger); color:#1a0505; }
+  body.iscustom .bbig { background:var(--busycustom,#a020f0); color:#fff; }
+  /* 2x2 rather than four across: at 260px, four columns would be 55px wide each, under the 48px
+     minimum once padding is counted, and the labels would not fit. */
+  .bgrid { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+  .bmode { height:64px; border-radius:12px; background:var(--surf); color:var(--fg);
+    font-size:18px; font-weight:700; border:0; display:flex; align-items:center; justify-content:center; gap:10px; }
+  .bmode.on { background:var(--accent); color:var(--accent-fg,#04121f); }
+  .bmode .sw { width:20px; height:20px; border-radius:50%; flex:0 0 auto; box-shadow:inset 0 0 0 2px rgba(255,255,255,.3); }
+  .bstat { font-size:15px; color:var(--dim); font-weight:600; text-align:center; min-height:20px; line-height:1.3; }
+  #btnBusyPanel { display:none; }
+  body.busyon #btnBusyPanel { display:block; }
+  body.busyon.isbusy #btnBusyPanel { box-shadow: inset 0 0 0 2px var(--danger); }
+
+  #bpick { display:none; position:absolute; inset:0; z-index:40; background:rgba(0,0,0,.55); }
+  body.bpicking #bpick { display:flex; align-items:center; justify-content:center; }
+  .bpbox { width:900px; background:var(--surf2); border-radius:18px; padding:24px; display:flex; flex-direction:column; gap:16px; }
+  .bphead { display:flex; align-items:center; gap:16px; }
+  .bptitle { font-size:26px; font-weight:800; flex:1; }
+  .bpclose { height:56px; min-width:56px; border-radius:12px; background:var(--surf); color:var(--dim); font-size:24px; font-weight:700; border:0; }
+  /* 4 x 2 so all eight fit with NO scrolling: 2 columns clipped the last row and fell back to a
+     native scrollbar, which is unusable with a finger. 2 rows x 72px + 12px gap = 156px, well inside
+     the 480px panel once the header and padding are counted. */
+  .bpgrid { display:grid; grid-template-columns:repeat(4, 1fr); gap:12px; }
+  .bpsw { height:96px; border-radius:12px; background:var(--surf); color:var(--fg); font-size:18px; font-weight:700;
+    display:flex; flex-direction:column; align-items:center; justify-content:center; gap:10px; border:0; }
+  .bpsw .dot { width:40px; height:40px; border-radius:50%; flex:0 0 auto; box-shadow:inset 0 0 0 2px rgba(255,255,255,.25); }
+  .bpsw.on { background:var(--accent); color:var(--accent-fg,#04121f); }
+
   /* ---- highlight column ---- */
   #hl { display:none; flex:0 0 260px; background:var(--surf2); border-radius:18px; padding:18px; flex-direction:column; gap:14px; }
   body.hlon.phl #hl { display:flex; }
@@ -267,6 +310,7 @@
       <button class="topBtn colBtn press foc" id="btnCtlPanel" type="button">Control</button>
       <button class="topBtn colBtn press foc" id="btnSlidePanel" type="button">Slide Capture</button>
       <button class="topBtn colBtn press foc" id="btnHlPanel" type="button">Highlight</button>
+      <button class="topBtn colBtn press foc" id="btnBusyPanel" type="button">Busy</button>
       <div id="status">Ready</div>
       <div id="spacer"></div>
       <button class="topBtn press foc" id="btnAnalysis" type="button">Analysis</button>
@@ -314,6 +358,25 @@
         <button class="hbig press foc" id="hlToggle" type="button"><span class="hglyph"></span><span class="hlbl">Start highlighting</span></button>
         <button class="hclear press foc" id="hlClear" type="button">Clear current highlight</button>
         <div class="hstat" id="hlStat"></div>
+      </div>
+
+      <div id="busy">
+        <div class="rlabel">BUSY STATUS</div>
+        <div class="bbig"><span class="bword" id="busyWord">Free</span><span class="bwhy" id="busyWhy">&nbsp;</span></div>
+        <div class="bgrid">
+          <button class="bmode press foc" id="busyAuto" type="button">Auto</button>
+          <button class="bmode press foc" id="busyBusy" type="button">Busy</button>
+          <button class="bmode press foc" id="busyFree" type="button">Free</button>
+          <button class="bmode press foc" id="busyCustom" type="button">Custom<span class="sw" id="busySw"></span></button>
+        </div>
+        <div class="bstat" id="busyStat"></div>
+      </div>
+
+      <div id="bpick">
+        <div class="bpbox">
+          <div class="bphead"><div class="bptitle">Custom colour</div><button class="bpclose foc" id="bpCancel" type="button">&times;</button></div>
+          <div class="bpgrid" id="bpGrid"></div>
+        </div>
       </div>
 
       <div id="scrim"></div>

--- a/app/meetingview.js
+++ b/app/meetingview.js
@@ -156,6 +156,7 @@ var PANELS = [
   { key: 'ctl',   btn: 'btnCtlPanel',   cls: 'pctl' },
   { key: 'slide', btn: 'btnSlidePanel', cls: 'pslide' },
   { key: 'hl',    btn: 'btnHlPanel',    cls: 'phl' },
+  { key: 'busy',  btn: 'btnBusyPanel',  cls: 'pbusy' },
 ];
 var panelsOpen = {};
 var panelsRestored = false;
@@ -173,6 +174,109 @@ function togglePanel(key) {
   fetch('/meeting-set-panels/' + encodeURIComponent(csv), { cache: 'no-store' }).catch(function () {});
 }
 PANELS.forEach(function (p) { $(p.btn).onclick = function () { togglePanel(p.key); }; });
+
+// =====================================================================================
+// Busy column — shows why you are showing busy and lets you override it. The page renders only what
+// /meeting-state.busy reports; every decision is made in main so the light, HA and the panel can
+// never disagree about the current state.
+// =====================================================================================
+var busyOverride = 'auto';
+var busyManualColor = '#a020f0';
+// Kept short and high-contrast on purpose: this is picked at arm's length on a touch panel, not in a
+// colour dialog. Names matter more than precision here.
+var BUSY_SWATCHES = [
+  ['#a020f0', 'Purple'], ['#ff0000', 'Red'], ['#ff8000', 'Orange'], ['#ffd000', 'Yellow'],
+  ['#00c853', 'Green'], ['#00b8d4', 'Cyan'], ['#2979ff', 'Blue'], ['#ff2d95', 'Pink'],
+];
+
+function setBusyOverride(mode) {
+  busyOverride = mode;
+  syncBusyModes();
+  fetch('/meeting-busy/' + encodeURIComponent(mode), { cache: 'no-store' }).catch(function () {});
+}
+function syncBusyModes() {
+  [['busyAuto', 'auto'], ['busyBusy', 'busy'], ['busyFree', 'free'], ['busyCustom', 'custom']]
+    .forEach(function (p) {
+      var el = $(p[0]); if (el) el.classList.toggle('on', busyOverride === p[1]);
+    });
+  var sw = $('busySw'); if (sw) sw.style.background = busyManualColor;
+  document.documentElement.style.setProperty('--busycustom', busyManualColor);
+}
+$('busyAuto').onclick = function () { setBusyOverride('auto'); };
+$('busyBusy').onclick = function () { setBusyOverride('busy'); };
+$('busyFree').onclick = function () { setBusyOverride('free'); };
+// Tap Custom to switch to it using the colour you already chose; tap it AGAIN, while it is already
+// active, to change that colour. Opening the picker on every tap would mean picking a colour you have
+// already picked each time you toggle custom on.
+$('busyCustom').onclick = function () {
+  if (busyOverride === 'custom') openBusyPicker();
+  else setBusyOverride('custom');
+};
+
+function openBusyPicker() {
+  var grid = $('bpGrid');
+  grid.innerHTML = '';
+  BUSY_SWATCHES.forEach(function (c) {
+    var b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'bpsw press foc' + (c[0].toLowerCase() === busyManualColor.toLowerCase() ? ' on' : '');
+    var dot = document.createElement('span');
+    dot.className = 'dot'; dot.style.background = c[0];
+    b.appendChild(dot);
+    b.appendChild(document.createTextNode(c[1]));
+    b.onclick = function () { pickBusyColor(c[0]); };
+    grid.appendChild(b);
+  });
+  document.body.classList.add('bpicking');
+}
+function closeBusyPicker() { document.body.classList.remove('bpicking'); }
+$('bpCancel').onclick = closeBusyPicker;
+$('bpick').onclick = function (e) { if (e.target === $('bpick')) closeBusyPicker(); };
+
+function pickBusyColor(hex) {
+  busyManualColor = hex;
+  syncBusyModes();
+  closeBusyPicker();
+  fetch('/meeting-busy-color/' + encodeURIComponent(hex), { cache: 'no-store' }).catch(function () {});
+}
+
+function busyReasonText(b) {
+  if (!b.busy) return b.override === 'free' ? 'Set by you' : 'Not on a call';
+  if (b.reason === 'custom') return 'Set by you';
+  if (b.reason === 'manual') return 'Set by you';
+  if (b.reason === 'recording') return 'Recording';
+  if (b.reason === 'call') return b.app ? b.app.replace(/\.exe$/i, '') : 'On a call';
+  return '';
+}
+// One short line per configured output, so a dead light or broker shows on the panel rather than only
+// in the editor. Silent failure is the thing worth surfacing.
+function busyOutputText(b) {
+  var out = b.outputs || {}, bits = [];
+  if (out.light && out.light.status && out.light.status !== 'disabled') {
+    bits.push(out.light.connected ? 'Light OK' : ('Light: ' + (out.light.error || 'not found')));
+  }
+  if (out.wled && out.wled.enabled) bits.push('WLED: ' + (out.wled.status || '…'));
+  if (out.mqtt && out.mqtt.enabled) bits.push(out.mqtt.connected ? 'HA OK' : 'HA: offline');
+  return bits.join('  ·  ');
+}
+function renderBusy(b) {
+  if (!b) b = { enabled: false };
+  document.body.classList.toggle('busyon', !!b.enabled);
+  if (!b.enabled) {
+    document.body.classList.remove('isbusy', 'iscustom');
+    return;
+  }
+  document.body.classList.toggle('isbusy', !!b.busy);
+  document.body.classList.toggle('iscustom', b.reason === 'custom');
+  var word = $('busyWord'); if (word) word.textContent = b.busy ? 'Busy' : 'Free';
+  var why = $('busyWhy'); if (why) why.textContent = busyReasonText(b) || ' ';
+  var stat = $('busyStat'); if (stat) stat.textContent = busyOutputText(b);
+  // Main owns both, so adopt rather than trust the local copy — a restart or an editor change must
+  // show here instead of the two drifting apart.
+  if (b.override && b.override !== busyOverride) busyOverride = b.override;
+  if (b.manualColor && b.manualColor !== busyManualColor) busyManualColor = b.manualColor;
+  syncBusyModes();
+}
 
 // =====================================================================================
 // Highlight column — tap to open a span, tap again to close it. Offsets are measured against the
@@ -224,6 +328,7 @@ function applyState(st) {
   $('recPanel').classList.toggle('details', live);
   if (curState.slide) applySlide(curState.slide);
   if (curState.highlight) applyHighlight(curState.highlight);
+  renderBusy(curState.busy);   // always called: it also clears body.busyon when the feature is off
   // Restore the remembered column set once, from the first poll that carries it — after that
   // the buttons own the state and a later poll must not undo a tap just made.
   if (!panelsRestored && typeof curState.panelsOpen === 'string') {

--- a/app/micMonitorRouting.js
+++ b/app/micMonitorRouting.js
@@ -1,0 +1,72 @@
+'use strict';
+// Routing for mic-session-monitor.exe lines, split out of main.js so it can be unit-tested without a
+// child process or a microphone.
+//
+// One monitor watches the UNION of two allowlists — the meeting recorder's call apps and the busy
+// light's call apps — because Windows shared-mode capture lets several apps hold the same microphone
+// at once, so a single "which app has the mic" answer is not enough. Each consumer therefore has to
+// re-derive its own answer from the full apps[] array:
+//
+//   - the recorder wants the first app that is on ITS list, and nothing else
+//   - the busy light only wants to know whether ANY app on its list is present
+//
+// The two traps this exists to avoid, both found in review and both since reproduced against real
+// capture sessions:
+//
+//   1. Reading msg.app. That is whichever process endpoint enumeration reached first, not the
+//      caller's app of interest. With Discord idling and Teams starting a call, msg.app stays
+//      "Discord.exe" and the recorder never fires.
+//   2. Driving auto-stop off msg.active. That flag is true while ANY watched app holds the mic, so
+//      with Discord permanently open a Teams call ending never produces active:false and the
+//      recording runs until the silence timer. Auto-stop must key off recordApp going undefined.
+
+// 'Zoom.exe, Teams.exe' -> Set { 'zoom.exe', 'teams.exe' }. Accepts comma/space/semicolon
+// separators, matching what mic-session-monitor.exe itself parses out of argv.
+function parseAppList(csv) {
+  const out = new Set();
+  String(csv == null ? '' : csv).split(/[,;\s]+/).forEach(part => {
+    const name = part.trim().toLowerCase();
+    if (name) out.add(name);
+  });
+  return out;
+}
+
+// The allowlist argument for the monitor: every app either consumer cares about, de-duplicated but
+// keeping the recorder's entries first so msg.app stays a record app in the common case (nothing
+// reads it, but it keeps the logs legible).
+function monitorAllowlist(recordApps, busyApps, busyEnabled) {
+  const seen = new Set();
+  const out = [];
+  const add = csv => String(csv == null ? '' : csv).split(/[,;\s]+/).forEach(part => {
+    const name = part.trim();
+    if (!name) return;
+    const key = name.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(name);
+  });
+  add(recordApps);
+  if (busyEnabled) add(busyApps);
+  return out.join(',');
+}
+
+// One parsed monitor line -> what each consumer should do about it.
+//
+// `recordApp` is the app the recorder should treat as the trigger, or null. `busyActive` is whether
+// the busy light should consider a call in progress. Neither is `msg.active`, deliberately.
+//
+// Older monitor builds emit no apps[] (only app). Falling back to [msg.app] keeps a stale
+// app/native/mic-session-monitor.exe working as it does today rather than silently reporting idle:
+// build-smtc.js regenerates the exe, but a packaged install could be mid-upgrade.
+function routeMonitorMessage(msg, recordSet, busySet) {
+  const m = msg || {};
+  const apps = Array.isArray(m.apps)
+    ? m.apps
+    : (m.active && m.app ? [m.app] : []);
+  const names = apps.map(a => String(a || '').trim()).filter(Boolean);
+  const recordApp = names.find(a => recordSet.has(a.toLowerCase())) || null;
+  const busyActive = names.some(a => busySet.has(a.toLowerCase()));
+  return { apps: names, recordApp, busyActive };
+}
+
+module.exports = { parseAppList, monitorAllowlist, routeMonitorMessage };

--- a/app/presence.js
+++ b/app/presence.js
@@ -1,0 +1,132 @@
+'use strict';
+// Busy-presence state machine: the single place that decides whether you are "busy", from three
+// independent inputs. Pure and dependency-free so the precedence and debounce rules can be tested
+// without a microphone, a light, or a broker — the outputs live in presenceService.js.
+//
+// Inputs, in order of precedence:
+//   override    'busy' | 'free' pins the state and wins over everything; 'auto' hands control back
+//   recording   open-quake is capturing a meeting
+//   call        an allowlisted call app holds the microphone
+//
+// The off-delay exists because a call app's capture session is not continuous. Teams in particular
+// drops and retakes the mic when the meeting window changes (joining, screen share starting), which
+// without a delay reads as call-ended immediately followed by call-started, and the light visibly
+// blinks in the middle of a meeting. Going busy is immediate; only going free waits.
+
+const DEFAULT_OFF_DELAY_MS = 5000;
+
+// deps.now and deps.setTimer exist so tests can drive time directly rather than sleeping.
+function createPresence(options) {
+  const opts = options || {};
+  const now = opts.now || (() => Date.now());
+  // Mutable, not captured once: the off-delay is a user setting and applySettings() must be able to
+  // change it on a live instance. Capturing it in a const meant edits to it silently did nothing.
+  let offDelayMs = Math.max(0, Number(opts.offDelayMs == null ? DEFAULT_OFF_DELAY_MS : opts.offDelayMs));
+  const onChange = typeof opts.onChange === 'function' ? opts.onChange : () => {};
+
+  let callActive = false;
+  let callApp = null;
+  let recording = false;
+  let recordingCounts = opts.busyOnRecording !== false;
+  let override = 'auto';
+
+  let busy = false;
+  let reason = null;
+  let since = null;
+  let pendingOffAt = null;   // when the off-delay expires, or null when nothing is pending
+  // The app as of the last emit. Comparing against the live callApp cannot detect a change, because
+  // setCall() has already updated it by the time evaluate() runs — that made a Teams -> Zoom switch
+  // silently skip its notification.
+  let emittedApp = null;
+
+  // What the inputs say right now, ignoring the off-delay. Override first, then recording, then call:
+  // recording outranks call so a manually started recording still reads as busy after the call app
+  // has let go of the mic.
+  function target() {
+    if (override === 'busy') return { busy: true, reason: 'manual', app: null };
+    // 'custom' is busy with a user-picked colour — a distinct reason so the fan-out can tell it apart
+    // from an ordinary manual busy and paint it differently.
+    if (override === 'custom') return { busy: true, reason: 'custom', app: null };
+    if (override === 'free') return { busy: false, reason: null, app: null };
+    if (recording && recordingCounts) return { busy: true, reason: 'recording', app: callApp };
+    if (callActive) return { busy: true, reason: 'call', app: callApp };
+    return { busy: false, reason: null, app: null };
+  }
+
+  function emit() { try { onChange(getState()); } catch (e) {} }
+
+  // Recompute after any input change. Returns true when the caller should re-check later, i.e. an
+  // off-delay is pending — presenceService drives that with a timer it owns.
+  function evaluate() {
+    const t = target();
+    const t0 = now();
+
+    if (t.busy) {
+      pendingOffAt = null;
+      const changed = !busy || reason !== t.reason || emittedApp !== t.app;
+      if (!busy) since = t0;
+      busy = true; reason = t.reason; emittedApp = t.app;
+      if (changed) emit();
+      return false;
+    }
+
+    // The debounce exists for ONE failure: a call app releasing and retaking the microphone
+    // mid-meeting, which is invisible to the user and would blink the light. Nothing else flaps.
+    //   - an explicit 'free' override is a deliberate act
+    //   - a recording stopping is a discrete event from our own recorder, not a flapping input
+    // Both take effect at once; only a call going quiet waits.
+    if (override === 'free' || offDelayMs === 0 || reason !== 'call') {
+      pendingOffAt = null;
+      if (busy) { busy = false; reason = null; emittedApp = null; since = t0; emit(); }
+      return false;
+    }
+
+    if (!busy) { pendingOffAt = null; return false; }
+    if (pendingOffAt == null) pendingOffAt = t0 + offDelayMs;
+    if (t0 >= pendingOffAt) {
+      pendingOffAt = null;
+      busy = false; reason = null; emittedApp = null; since = t0;
+      emit();
+      return false;
+    }
+    return true;
+  }
+
+  function getState() {
+    return {
+      busy,
+      reason,
+      app: busy && (reason === 'call' || reason === 'recording') ? callApp : null,
+      since,
+      override,
+      callActive,
+      callApp,
+      recording,
+      pendingOff: pendingOffAt != null,
+    };
+  }
+
+  return {
+    // A call app took or released the mic. `app` is the matched process name, or null.
+    setCall(active, app) {
+      callActive = !!active;
+      callApp = callActive ? (app || null) : null;
+      return evaluate();
+    },
+    setRecording(on) { recording = !!on; return evaluate(); },
+    setOverride(mode) {
+      override = (mode === 'busy' || mode === 'free' || mode === 'custom') ? mode : 'auto';
+      return evaluate();
+    },
+    // Settings changed under us (busyOnRecording toggled). Kept separate from construction so the
+    // service can apply an edited config without losing the current call/recording inputs.
+    setRecordingCounts(on) { recordingCounts = on !== false; return evaluate(); },
+    setOffDelay(ms) { offDelayMs = Math.max(0, Number(ms) || 0); return evaluate(); },
+    getOffDelayMs() { return offDelayMs; },
+    // Called by the owner's timer while an off-delay is pending; returns true while still pending.
+    tick() { return evaluate(); },
+    getState,
+  };
+}
+
+module.exports = { createPresence, DEFAULT_OFF_DELAY_MS };

--- a/app/presenceMqtt.js
+++ b/app/presenceMqtt.js
@@ -1,0 +1,214 @@
+'use strict';
+// Publishes busy presence to Home Assistant over MQTT discovery.
+//
+// WHY MQTT AND NOT THE HA REST API: HA's WebSocket API has no equivalent of POST /api/states, so an
+// entity published from outside HA can only be created over REST — and a REST-created state does not
+// survive an HA restart, which would mean heartbeating forever to keep a phantom entity alive. MQTT
+// discovery gives a real, persistent, auto-provisioned entity with no manual setup in HA at all.
+//
+// THE WILL IS THE POINT. The availability topic is registered as the MQTT last-will at CONNECT time,
+// so if open-quake is killed, crashes, or loses power, the broker publishes 'offline' on our behalf
+// and every HA automation sees the entity go unavailable. That is the exact counterpart to the
+// Busylight's own 30s keepalive timeout: both ends fail safe without anyone remembering to clean up.
+//
+// CONSEQUENCE, and the easiest thing to get wrong here: the connection MUST be long-lived. A client
+// that connects, publishes, and disconnects per state change has no will registered between changes,
+// which throws away the entire failsafe. Open once, keep it, let MQTT.js reconnect.
+
+const os = require('os');
+
+const DISCOVERY_PREFIX = 'homeassistant';
+const OBJECT_ID = 'open_quake_busy';
+
+// A hostname is not guaranteed to be topic-safe (MQTT dislikes '+', '#', '/'), and HA object ids
+// want [a-z0-9_]. Normalise once, here, so topic and unique_id can never disagree.
+function safeNodeId(hostname) {
+  const s = String(hostname || 'open-quake').toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return s || 'open-quake';
+}
+
+function buildTopics(baseTopic, hostname) {
+  const base = String(baseTopic || 'open-quake').replace(/^\/+|\/+$/g, '') || 'open-quake';
+  const node = safeNodeId(hostname);
+  return {
+    node,
+    state: base + '/' + node + '/busy',
+    attributes: base + '/' + node + '/attributes',
+    availability: base + '/' + node + '/availability',
+    discovery: DISCOVERY_PREFIX + '/binary_sensor/' + node + '_' + OBJECT_ID + '/config',
+  };
+}
+
+// The retained discovery document HA reads to create the entity. `device` groups it under one
+// "open-quake" device rather than leaving a loose entity, and unique_id is what makes it editable in
+// the HA UI and stable across restarts.
+function buildDiscoveryConfig(topics, opts) {
+  const o = opts || {};
+  return {
+    name: o.name || 'Busy',
+    unique_id: topics.node + '_' + OBJECT_ID,
+    object_id: OBJECT_ID,
+    state_topic: topics.state,
+    payload_on: 'ON',
+    payload_off: 'OFF',
+    availability_topic: topics.availability,
+    payload_available: 'online',
+    payload_not_available: 'offline',
+    json_attributes_topic: topics.attributes,
+    // 'occupancy' reads as Detected/Clear in the UI, which is the closest built-in wording for
+    // "someone is on a call". Not 'sound' — that implies noise, not availability.
+    device_class: 'occupancy',
+    icon: 'mdi:video-account',
+    device: {
+      identifiers: [topics.node + '_open_quake'],
+      name: 'open-quake (' + topics.node + ')',
+      manufacturer: 'open-quake',
+      model: 'Presence',
+    },
+  };
+}
+
+// State -> the two payloads published on every change. Kept pure and separate from the client so the
+// mapping can be tested without a broker.
+function buildPayloads(state) {
+  const s = state || {};
+  return {
+    state: s.busy ? 'ON' : 'OFF',
+    attributes: {
+      reason: s.reason || null,
+      app: s.app || null,
+      since: s.since ? new Date(s.since).toISOString() : null,
+      recording: !!s.recording,
+      override: s.override || 'auto',
+    },
+  };
+}
+
+// deps.mqtt is injected for tests; production lazily requires the real module.
+function createPresenceMqtt(deps) {
+  const d = deps || {};
+  const log = d.log || (() => {});
+  let mqttLib = d.mqtt || null;
+  let client = null;
+  let topics = null;
+  let discovery = null;
+  let settings = null;
+  let lastState = null;
+  let lastError = null;
+  let connected = false;
+
+  function loadMqtt() {
+    if (mqttLib) return mqttLib;
+    try { mqttLib = require('mqtt'); } catch (e) { lastError = 'mqtt module unavailable: ' + e.message; }
+    return mqttLib;
+  }
+
+  function publish(topic, payload, opts) {
+    if (!client) return false;
+    try {
+      client.publish(topic, typeof payload === 'string' ? payload : JSON.stringify(payload),
+        Object.assign({ qos: 0, retain: true }, opts || {}));
+      return true;
+    } catch (e) { lastError = e.message; return false; }
+  }
+
+  // Everything that must be re-asserted after a (re)connect. A broker restart drops retained
+  // messages, so re-publishing discovery and current state here is what makes the entity heal
+  // itself rather than sitting unavailable until the next busy transition.
+  function announce() {
+    if (!client || !topics) return;
+    publish(topics.discovery, discovery);
+    publish(topics.availability, 'online');
+    // Always publish a state, even before anything has happened. An entity that is available but has
+    // never received a state shows as "unknown" in HA, which no automation can sensibly branch on —
+    // and "unknown" is indistinguishable from "broken" to whoever is looking at the dashboard.
+    // Not-yet-busy is honestly OFF.
+    const p = buildPayloads(lastState || { busy: false });
+    publish(topics.state, p.state);
+    publish(topics.attributes, p.attributes);
+  }
+
+  function stop() {
+    if (!client) { connected = false; return; }
+    const c = client;
+    client = null;
+    connected = false;
+    try {
+      // A clean quit should say offline immediately rather than waiting for the broker to notice a
+      // dropped socket and fire the will.
+      if (topics) c.publish(topics.availability, 'offline', { qos: 0, retain: true });
+      c.end(false);
+    } catch (e) {}
+  }
+
+  return {
+    // Idempotent: safe to call whenever settings change. Reconnects only when the connection
+    // parameters actually changed, so editing an unrelated setting does not drop the will.
+    apply(next) {
+      const n = next || {};
+      const same = settings &&
+        settings.enabled === !!n.enabled &&
+        settings.url === (n.url || '') &&
+        settings.username === (n.username || '') &&
+        settings.password === (n.password || '') &&
+        settings.baseTopic === (n.baseTopic || '');
+      if (same) return;
+      settings = {
+        enabled: !!n.enabled, url: n.url || '', username: n.username || '',
+        password: n.password || '', baseTopic: n.baseTopic || 'open-quake',
+      };
+      stop();
+      if (!settings.enabled) return;
+      if (!settings.url) { lastError = 'broker URL required'; return; }
+      const lib = loadMqtt();
+      if (!lib) return;
+
+      topics = buildTopics(settings.baseTopic, d.hostname || os.hostname());
+      discovery = buildDiscoveryConfig(topics, {});
+      try {
+        client = lib.connect(settings.url, {
+          username: settings.username || undefined,
+          password: settings.password || undefined,
+          clientId: 'open-quake-' + topics.node,
+          reconnectPeriod: 10000,
+          connectTimeout: 10000,
+          // Registered at CONNECT. This is the crash failsafe — see the header.
+          will: { topic: topics.availability, payload: 'offline', qos: 0, retain: true },
+        });
+      } catch (e) { lastError = e.message; client = null; return; }
+
+      client.on('connect', () => { connected = true; lastError = null; log('mqtt connected'); announce(); });
+      client.on('reconnect', () => { log('mqtt reconnecting'); });
+      client.on('close', () => { connected = false; });
+      // Without a handler MQTT.js emits an unhandled 'error' and takes the process down. A bad
+      // broker address must never be able to kill the app.
+      client.on('error', e => { connected = false; lastError = e && e.message ? e.message : String(e); });
+    },
+
+    publishState(state) {
+      lastState = state || null;
+      if (!client || !topics || !lastState) return false;
+      const p = buildPayloads(lastState);
+      const a = publish(topics.state, p.state);
+      const b = publish(topics.attributes, p.attributes);
+      return a && b;
+    },
+
+    status() {
+      return {
+        enabled: !!(settings && settings.enabled),
+        connected,
+        error: lastError,
+        entity: topics ? 'binary_sensor.' + OBJECT_ID : null,
+        topics,
+      };
+    },
+
+    stop,
+  };
+}
+
+module.exports = {
+  createPresenceMqtt, buildTopics, buildDiscoveryConfig, buildPayloads, safeNodeId,
+  DISCOVERY_PREFIX, OBJECT_ID,
+};

--- a/app/presenceService.js
+++ b/app/presenceService.js
@@ -1,0 +1,264 @@
+'use strict';
+// Ties the presence state machine to its outputs: the USB Busylight, a DIY WLED light, and Home
+// Assistant over MQTT. Owns the off-delay timer that presence.js deliberately does not own.
+//
+// ISOLATION RULE, and it is the reason every call here is wrapped: an output failing must never take
+// down another output, the meeting recorder, or the app. A broker that is down, a light that was
+// unplugged, and a mistyped WLED address are all normal Tuesday conditions. Each one degrades to a
+// status string that the settings page can show, and nothing else changes.
+
+const { createPresence } = require('./presence');
+const { createBusylightService, parseColor } = require('./busylightService');
+const { createPresenceMqtt } = require('./presenceMqtt');
+const busySchedule = require('./busySchedule');
+
+const WLED_TIMEOUT_MS = 3000;
+
+const DEFAULTS = {
+  busyEnabled: false,
+  busyOnRecording: true,
+  busyOffDelaySec: 5,
+  busyLightEnabled: false,
+  busyLightBusyColor: '#ff0000',
+  busyLightFreeColor: '#00ff00',
+  busyLightBrightness: 100,
+  busyManualColor: '#a020f0',
+  busyLightFreeOff: false,
+  busySchedEnabled: false,
+  busySchedDays: '1,2,3,4,5',
+  busySchedStart: '08:00',
+  busySchedEnd: '17:00',
+  busySchedPerDay: false,
+  busySchedTimes: {},
+  busyWledEnabled: false,
+  busyWledHost: '',
+  busyMqttEnabled: false,
+  busyMqttUrl: '',
+  busyMqttUser: '',
+  busyMqttPassword: '',
+  busyMqttBaseTopic: 'open-quake',
+};
+
+// 'http://1.2.3.4', '1.2.3.4', '1.2.3.4:8080' -> a usable origin. WLED is plain HTTP on the LAN and
+// users will type a bare IP, so default the scheme rather than rejecting it.
+function wledUrl(host, path) {
+  const h = String(host || '').trim().replace(/\/+$/, '');
+  if (!h) return null;
+  const base = /^https?:\/\//i.test(h) ? h : 'http://' + h;
+  return base + path;
+}
+
+// WLED gotcha: turning on from off and setting a colour in the same request can be ignored, so
+// brightness is always sent explicitly alongside on and the colour.
+function wledBody(color, on) {
+  if (!on) return { on: false };
+  return { on: true, bri: 255, seg: [{ col: [[color.r, color.g, color.b]] }] };
+}
+
+function createPresenceService(deps) {
+  const d = deps || {};
+  const log = d.log || (() => {});
+  const fetchImpl = d.fetch || (typeof fetch === 'function' ? fetch : null);
+
+  let settings = Object.assign({}, DEFAULTS);
+  let offTimer = null;
+  let lastApplied = null;
+
+  const busylight = d.busylight || createBusylightService({ log, hid: d.hid });
+  const mqtt = d.mqtt || createPresenceMqtt({ log, mqtt: d.mqttLib, hostname: d.hostname });
+  const outputStatus = { light: null, wled: null };
+
+  const presence = createPresence({
+    offDelayMs: (Number(settings.busyOffDelaySec) || 0) * 1000,
+    busyOnRecording: settings.busyOnRecording,
+    onChange: state => applyOutputs(state),
+  });
+
+  // presence.js reports "an off-delay is pending" rather than owning a timer, so the schedule lives
+  // here. One shot per pending window; re-armed by whichever input changes next.
+  function armOffTimer(pending) {
+    if (offTimer) { clearTimeout(offTimer); offTimer = null; }
+    if (!pending) return;
+    offTimer = setTimeout(() => {
+      offTimer = null;
+      if (presence.tick()) armOffTimer(true);
+    }, Math.max(50, presence.getOffDelayMs()));
+    if (offTimer.unref) offTimer.unref();
+  }
+
+  // A manual override shows its own colour so "busy because I said so" is distinguishable at a glance
+  // from "busy because Teams has the mic" — that is the whole point of setting it by hand.
+  function busyColorFor(state) {
+    return state && state.reason === 'custom' && settings.busyManualColor
+      ? settings.busyManualColor
+      : settings.busyLightBusyColor;
+  }
+
+  function scheduleView() {
+    return {
+      enabled: !!settings.busySchedEnabled, days: settings.busySchedDays,
+      start: settings.busySchedStart, end: settings.busySchedEnd,
+      perDay: !!settings.busySchedPerDay, times: settings.busySchedTimes || {},
+    };
+  }
+  // Scoped to the USB light only. WLED and the HA entity keep reporting outside the window — the
+  // schedule is about not lighting up your desk after hours, not about withholding the state.
+  function lightScheduled() { return busySchedule.isActive(new Date(), scheduleView()); }
+
+  function applyLight(state) {
+    if (!settings.busyEnabled || !settings.busyLightEnabled) { busylight.close(); outputStatus.light = 'disabled'; return; }
+    if (!lightScheduled()) {
+      // Off, not merely "don't update": crossing out of the window while busy must actively clear a
+      // light that is currently red.
+      try { busylight.off(); } catch (e) {}
+      outputStatus.light = 'outside schedule';
+      return;
+    }
+    try {
+      if (state.busy) {
+        const c = parseColor(busyColorFor(state), settings.busyLightBrightness);
+        outputStatus.light = busylight.setColor(c) ? 'busy' : (busylight.status().error || 'write failed');
+      } else if (settings.busyLightFreeOff) {
+        busylight.off();
+        outputStatus.light = 'free (off)';
+      } else {
+        const c = parseColor(settings.busyLightFreeColor, settings.busyLightBrightness);
+        outputStatus.light = busylight.setColor(c) ? 'free' : (busylight.status().error || 'write failed');
+      }
+    } catch (e) { outputStatus.light = e.message; }
+  }
+
+  function applyWled(state) {
+    if (!settings.busyEnabled || !settings.busyWledEnabled) { outputStatus.wled = 'disabled'; return Promise.resolve(); }
+    const url = wledUrl(settings.busyWledHost, '/json/state');
+    if (!url) { outputStatus.wled = 'host required'; return Promise.resolve(); }
+    if (!fetchImpl) { outputStatus.wled = 'fetch unavailable'; return Promise.resolve(); }
+    const color = parseColor(state.busy ? busyColorFor(state) : settings.busyLightFreeColor, settings.busyLightBrightness);
+    const on = state.busy || !settings.busyLightFreeOff;
+    // A slow or absent light must not stall the fan-out, so this is fire-and-forget with a timeout
+    // and the outcome recorded for the settings page.
+    const ac = typeof AbortController === 'function' ? new AbortController() : null;
+    const timer = ac ? setTimeout(() => ac.abort(), WLED_TIMEOUT_MS) : null;
+    return Promise.resolve()
+      .then(() => fetchImpl(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(wledBody(color, on)),
+        signal: ac ? ac.signal : undefined,
+      }))
+      .then(r => { outputStatus.wled = r && r.ok ? 'ok' : 'HTTP ' + (r && r.status); })
+      .catch(e => { outputStatus.wled = e && e.name === 'AbortError' ? 'timeout' : (e.message || String(e)); })
+      .finally(() => { if (timer) clearTimeout(timer); });
+  }
+
+  function applyOutputs(state) {
+    applyLight(state);
+    applyWled(state);
+    try { mqtt.publishState(state); } catch (e) {}
+    try { if (d.onState) d.onState(getState()); } catch (e) {}
+  }
+
+  function getState() {
+    const s = presence.getState();
+    return {
+      enabled: !!settings.busyEnabled,
+      busy: s.busy,
+      reason: s.reason,
+      app: s.app,
+      since: s.since,
+      override: s.override,
+      manualColor: settings.busyManualColor,
+      busyColor: settings.busyLightBusyColor,
+      recording: s.recording,
+      callActive: s.callActive,
+      outputs: {
+        light: Object.assign({ status: outputStatus.light, scheduled: lightScheduled(),
+          schedule: busySchedule.describe(scheduleView()) }, busylight.status()),
+        wled: { enabled: !!settings.busyWledEnabled, status: outputStatus.wled },
+        mqtt: mqtt.status(),
+      },
+    };
+  }
+
+  // Nothing about presence changes when the clock crosses 17:00, so without a tick the light would
+  // stay red until the next call event. 30s is well inside a minute-granular schedule.
+  let schedTimer = null;
+  let lastScheduled = null;
+  function startScheduleWatch() {
+    if (schedTimer) return;
+    schedTimer = setInterval(() => {
+      const now = lightScheduled();
+      if (now !== lastScheduled) { lastScheduled = now; applyOutputs(presence.getState()); }
+    }, 30000);
+    if (schedTimer.unref) schedTimer.unref();
+  }
+  function stopScheduleWatch() { if (schedTimer) { clearInterval(schedTimer); schedTimer = null; } }
+
+  return {
+    // Called at boot and whenever the editor saves. Re-applies everything that changed and leaves
+    // the live inputs (call/recording/override) alone.
+    applySettings(next) {
+      const prev = settings;
+      settings = Object.assign({}, DEFAULTS, next || {});
+      presence.setRecordingCounts(settings.busyOnRecording);
+      presence.setOffDelay((Number(settings.busyOffDelaySec) || 0) * 1000);
+      mqtt.apply({
+        enabled: !!(settings.busyEnabled && settings.busyMqttEnabled),
+        url: settings.busyMqttUrl,
+        username: settings.busyMqttUser,
+        password: settings.busyMqttPassword,
+        baseTopic: settings.busyMqttBaseTopic,
+      });
+      // Turning the feature (or the light) off must actively clear the light rather than leaving
+      // whatever it last showed lit until the device's own timeout.
+      if (prev.busyLightEnabled && !(settings.busyEnabled && settings.busyLightEnabled)) {
+        try { busylight.close(); } catch (e) {}
+      }
+      lastApplied = Date.now();
+      lastScheduled = lightScheduled();
+      if (settings.busyEnabled && settings.busyLightEnabled && settings.busySchedEnabled) startScheduleWatch();
+      else stopScheduleWatch();
+      applyOutputs(presence.getState());
+    },
+
+    setCall(active, app) { armOffTimer(presence.setCall(active, app)); },
+    setRecording(on) { armOffTimer(presence.setRecording(on)); },
+    setOverride(mode) { armOffTimer(presence.setOverride(mode)); return getState(); },
+    // Panel colour picker. Applied immediately so the light changes under your finger; main persists it.
+    setManualColor(hex) {
+      settings.busyManualColor = hex;
+      applyOutputs(presence.getState());
+      return getState();
+    },
+
+    getState,
+    // Used by the editor's Test buttons. Drives one output directly without disturbing real state.
+    test(target) {
+      if (target === 'light') {
+        const c = parseColor(settings.busyLightBusyColor, settings.busyLightBrightness);
+        const ok = busylight.setColor(c);
+        setTimeout(() => applyLight(presence.getState()), 2000);
+        return Object.assign({ ok }, busylight.status());
+      }
+      if (target === 'wled') {
+        return applyWled({ busy: true }).then(() => {
+          setTimeout(() => applyWled(presence.getState()), 2000);
+          return { ok: outputStatus.wled === 'ok', status: outputStatus.wled };
+        });
+      }
+      if (target === 'mqtt') return mqtt.status();
+      return { ok: false, error: 'unknown test target' };
+    },
+
+    // Quit path: clear the light now rather than relying on its 30s timeout, and tell HA we are gone
+    // rather than making the broker notice a dead socket.
+    stop() {
+      if (offTimer) { clearTimeout(offTimer); offTimer = null; }
+      stopScheduleWatch();
+      try { busylight.close(); } catch (e) {}
+      try { mqtt.stop(); } catch (e) {}
+    },
+  };
+}
+
+module.exports = { createPresenceService, wledUrl, wledBody, DEFAULTS };

--- a/app/secretStore.js
+++ b/app/secretStore.js
@@ -118,6 +118,12 @@ function createSecretStore({ safeStorage, dpapi, loadApps, log = () => {} }) {
     if (me && typeof me === 'object' && typeof me.joplinToken === 'string' && me.joplinToken !== '') {
       me.joplinToken = fn(me.joplinToken);
     }
+    // Busy-presence MQTT broker password. Registered here for the same reason as every entry above:
+    // a secret that is not listed in this function is written to config.json in cleartext, and
+    // nothing about the app looks or behaves any differently when that happens.
+    if (me && typeof me === 'object' && typeof me.busyMqttPassword === 'string' && me.busyMqttPassword !== '') {
+      me.busyMqttPassword = fn(me.busyMqttPassword);
+    }
     const oauth = config && config.settings && config.settings.oauth;
     if (oauth && typeof oauth === 'object') {
       const providers = oauth.providers && typeof oauth.providers === 'object' ? oauth.providers : {};

--- a/app/sysserver.js
+++ b/app/sysserver.js
@@ -1074,6 +1074,24 @@ async function handler(req, res) {
     }
     return json(res, result);
   }
+  // Manual busy override from the meeting panel's Busy column. Side-effecting, so it inherits the
+  // same loopback + Host-header + same-origin gating as every other /meeting-* route above.
+  if (url.indexOf('/meeting-busy/') === 0) {
+    const mode = decodeURIComponent(url.slice('/meeting-busy/'.length));
+    let result = { ok: false, error: 'not wired' };
+    if (typeof onMeetingRecord === 'function') {
+      try { result = await onMeetingRecord('busyOverride', mode); } catch (e) { result = { ok: false, error: e.message || 'busy-override failed' }; }
+    }
+    return json(res, result);
+  }
+  if (url.indexOf('/meeting-busy-color/') === 0) {
+    const hex = decodeURIComponent(url.slice('/meeting-busy-color/'.length));
+    let result = { ok: false, error: 'not wired' };
+    if (typeof onMeetingRecord === 'function') {
+      try { result = await onMeetingRecord('busyColor', hex); } catch (e) { result = { ok: false, error: e.message || 'busy-color failed' }; }
+    }
+    return json(res, result);
+  }
   if (url.indexOf('/meeting-set-mic/') === 0) {
     const label = decodeURIComponent(url.slice('/meeting-set-mic/'.length));
     let result = { ok: false, error: 'not wired' };

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Detailed guides for open-quake. Back to the [project README](../README.md).
 - **[Apps & drop-ins](apps.md)** — bundled apps, writing your own, and the drop-in app manager
 - **[Community apps](community-apps.md)** — install or submit shared drop-in apps
 - **[Music controller](music.md)** — now-playing, transport, album art, lyrics, button strip
-- **[Meeting](meeting.md)** — one-tap mute/video/accept/decline/leave for Zoom and Teams
+- **[Meeting](meeting.md)** — one-tap mute/video/accept/decline/leave for Zoom and Teams, plus a busy light that turns red while you are on a call (Kuando Busylight over USB, WLED, or Home Assistant over MQTT) — see [Settings → Meeting](settings.md) and [Home Assistant](home-assistant.md)
 - **[System monitor](system-monitor.md)** — live CPU/GPU/RAM/disk/network/battery
 - **[Open WebUI chat + voice](ai-chat.md)** — chat to your LLM, hold the knob to talk
 - **[AI Voice](ai-voice.md)** — one voice+text app, five backends: a real Claude Code / Codex / Copilot agent session (talk or type, touch approvals), or plain chat against Open WebUI or any OpenAI-compatible API with your own key

--- a/docs/home-assistant.md
+++ b/docs/home-assistant.md
@@ -106,6 +106,43 @@ Toggling **Use Home Assistant** off:
 
 The in-memory cache from a previous Use-HA-on session sticks around until app restart.
 
+## Publishing your busy status to HA (MQTT)
+
+The HA connection above is **read-only** — it pulls dashboards, registries and entity states, and
+calls services for entity tiles. Publishing *out* of open-quake goes over MQTT instead, configured
+separately under **Settings → Meeting → Busy status → Home Assistant (MQTT)**.
+
+MQTT rather than the REST API for one concrete reason: HA's WebSocket API has no equivalent of
+`POST /api/states`, and a state created over REST does not survive an HA restart — it would need an
+indefinite heartbeat to keep a phantom entity alive. MQTT discovery creates a real, persistent entity
+with nothing to configure on the HA side.
+
+What open-quake publishes (topics use `<prefix>/<hostname>/…`, prefix configurable, default
+`open-quake`):
+
+| Topic | Retained | Payload |
+|---|---|---|
+| `homeassistant/binary_sensor/<host>_open_quake_busy/config` | yes | discovery document; HA creates `binary_sensor.open_quake_busy` from it |
+| `open-quake/<host>/busy` | yes | `ON` / `OFF` |
+| `open-quake/<host>/attributes` | yes | `{reason, app, since, recording, override}` |
+| `open-quake/<host>/availability` | yes | `online` / `offline` |
+
+`reason` is `call`, `recording`, or `manual`, so an automation can distinguish "on a Teams call" from
+"marked busy by hand".
+
+The availability topic is registered as the MQTT **last will**, which is the part worth understanding:
+if open-quake is killed, crashes, or the PC loses power, the *broker* publishes `offline` on its
+behalf and the entity goes unavailable. A light driven from this entity therefore cannot get stuck
+showing you as busy — and neither can the USB Busylight, which extinguishes itself when open-quake
+stops sending its keep-alive. Both ends fail safe without anything having to run cleanup code.
+
+The connection is held open for as long as the feature is enabled, not opened per update: the will is
+registered at connect time, so a connect-publish-disconnect cycle would leave no will in force between
+updates and defeat the whole arrangement. On reconnect, open-quake re-publishes the discovery document
+and current state, because a broker restart drops retained messages.
+
+The broker password is encrypted at rest with the same DPAPI mechanism as the HA token.
+
 ## Privacy
 
 All HA traffic goes directly from open-quake's main process to your HA URL. No third party touches your tokens, dashboards, entity names, or registry data. The only external request the HA integration makes is to jsDelivr (`cdn.jsdelivr.net`) for individual MDI icon SVGs — those are public assets and the request carries no HA data.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -110,6 +110,62 @@ Recording and transcription for the Meeting panel (details in [meeting.md](meeti
   notes.
 - **Auto-record / Call apps / Stop after silence / Echo-gate** — unchanged recording
   behavior options.
+- **Busy status** — off by default. Turns a busy light red while a call app has your
+  microphone, and back to free when the call ends, replacing the light vendor's own
+  software. It uses the same app-scoped detection as auto-record, so it never triggers
+  on Claude voice or other microphone use.
+  - **Call apps** is a *separate* list from the auto-record one above, because the calls
+    worth showing a light for are usually more than the calls worth recording (Discord,
+    Slack and Webex are in the default list; the recorder's is not).
+  - **Also show busy while open-quake is recording** keeps the light on for a recording
+    you started by hand, after the call app has let go of the microphone.
+  - **Return to free after** is a short delay before going free. Teams releases and
+    retakes the microphone when its meeting window changes; without the delay the light
+    visibly blinks mid-meeting. Going *busy* is always immediate.
+  - **Busy light (USB)** drives a Kuando Busylight directly. **Kuando's own "Busylight
+    for UC" software must be closed or uninstalled** — Windows lets only one program hold
+    the device, so with both running the light appears to flicker or ignore open-quake.
+    That is the first thing to check if the light misbehaves. **Test light** confirms the
+    connection; the status line beside the checkbox reports the model it found.
+  - **Busylight schedule** — off by default. Restricts the Busylight to chosen days and
+    hours; outside the window it stays off. Tick the days (Mon–Fri by default) and set a
+    start and stop time. **Use different hours for each day** replaces the shared pair with
+    a start and stop for every ticked day.
+    - An end time earlier than the start runs the window **overnight**: `22:00`–`06:00` with
+      Friday ticked keeps the light active until 06:00 on Saturday, without ticking Saturday.
+      The window belongs to the day it started.
+    - Unticking every day means the light never comes on. An unparseable time is ignored and
+      the light works as if unscheduled, rather than going mysteriously dark.
+    - The schedule applies to the **USB Busylight only**. The Home Assistant entity and any
+      WLED light keep reporting your real status outside the window.
+  - **DIY light (WLED)** drives an ESP32 running WLED over the network — enter its IP
+    address. It uses the same busy and free colours.
+  - **Home Assistant (MQTT)** publishes a `binary_sensor.open_quake_busy` entity, created
+    automatically through MQTT discovery — nothing to configure on the Home Assistant
+    side. Automations trigger on it like any other sensor, and the attributes carry why
+    you are busy, which app, and since when. This is independent of the Home Assistant
+    connection on the **Auth** tab, which stays read-only. The broker password is
+    encrypted at rest.
+  - If open-quake stops, crashes, or the PC loses power, the light goes dark on its own
+    (the device requires a keep-alive) and the Home Assistant entity goes *unavailable*
+    (an MQTT last-will). Neither can get stuck showing you as busy.
+  - **Custom colour** is the colour the panel's **Custom** mode shows. Pick it here or on
+    the panel itself.
+  - On the panel, an opt-in **Busy** column shows the current state and offers four modes:
+    - **Auto** — follow the microphone and the recorder. The normal setting.
+    - **Busy** — force busy in the ordinary busy colour, for deep work or an in-person
+      visitor that no microphone can detect.
+    - **Free** — force free, even during a live call.
+    - **Custom** — force busy in your own colour, so "busy because I said so" looks
+      different from "busy because Teams has the mic". Tap **Custom** to switch to it using
+      the colour you last chose; tap it again while it is already active to change that
+      colour from eight presets. The choice is saved and survives a restart.
+
+    The state shown at the top of the column is what you *are* right now; the four buttons
+    are the mode you have *chosen*. In **Auto** those differ, which is the point.
+
+    The **Busy** button in the panel's top bar gains a red ring while you are busy, so the
+    state is visible with the column closed.
 - **Advanced → Pull meeting information from my calendar** — off by default. Choose a
   **Calendar source**:
   - **Classic Outlook (this PC)** attaches to the running OUTLOOK.EXE through COM and

--- a/native/mic-session-monitor.cs
+++ b/native/mic-session-monitor.cs
@@ -11,8 +11,16 @@
 //
 // Protocol: one JSON line per state transition, flushed immediately. Nothing is emitted until a
 // real transition is observed — there is deliberately no initial baseline line (see Main).
-//   {"active":true,"app":"Zoom.exe"}
-//   {"active":false}
+//   {"active":true,"app":"Zoom.exe","apps":["Zoom.exe","Discord.exe"]}
+//   {"active":false,"apps":[]}
+//
+// "apps" carries EVERY allowlisted process currently holding a capture session, because Windows
+// shared-mode capture lets several apps hold the same microphone at once — which is also why
+// open-quake can record your mic while Teams is in a call. One caller may watch a superset of
+// another's allowlist (the recorder wants Zoom/Teams; the busy light also wants Discord/Slack), so
+// each consumer filters "apps" against its own list. "app" is kept as the first match only so an
+// older reader does not break; new code must NOT use it, because the first match is whichever
+// endpoint enumeration reached first and is not necessarily the caller's app of interest.
 // Args: allowlist exe names, comma- or space-separated (one or many args). Defaults to
 //   Zoom.exe,Teams.exe,ms-teams.exe when none are given.
 //
@@ -102,9 +110,15 @@ class MicSessionMonitor {
 
     static Guid IID_IAudioSessionManager2 = new Guid("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F");
 
-    // Is any allowlisted process currently holding an active capture session? Returns the matched
-    // exe name (e.g. "Zoom.exe") or null. Releases every COM object it touches — this runs forever.
-    static string ActiveAllowlistedApp(HashSet<string> allow) {
+    // Every allowlisted process currently holding an active capture session, in enumeration order and
+    // de-duplicated (one app can hold sessions on several endpoints). Empty when none. This walks all
+    // sessions rather than returning on the first hit: stopping early would report whichever app
+    // enumeration happened to reach first and hide the rest, which silently breaks auto-record when a
+    // busy-only app is also holding the microphone.
+    // Releases every COM object it touches — this runs forever.
+    static List<string> ActiveAllowlistedApps(HashSet<string> allow) {
+        var found = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         IMMDeviceEnumerator devEnum = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
         IMMDeviceCollection coll = null;
         try {
@@ -129,7 +143,7 @@ class MicSessionMonitor {
                             int pid; ctl2.GetProcessId(out pid);
                             if (pid <= 0) continue;
                             string name = ProcessExeName(pid);
-                            if (name != null && allow.Contains(name.ToLowerInvariant())) return name;
+                            if (name != null && allow.Contains(name) && seen.Add(name)) found.Add(name);
                         } catch { /* system-sounds session etc. — skip */ }
                         finally { if (ctl != null) Marshal.ReleaseComObject(ctl); }
                     }
@@ -144,7 +158,7 @@ class MicSessionMonitor {
             if (coll != null) Marshal.ReleaseComObject(coll);
             if (devEnum != null) Marshal.ReleaseComObject(devEnum);
         }
-        return null;
+        return found;
     }
 
     static string ProcessExeName(int pid) {
@@ -153,38 +167,54 @@ class MicSessionMonitor {
     }
 
     static int Main(string[] args) {
-        var allow = new HashSet<string>();
+        // OrdinalIgnoreCase throughout: ProcessExeName returns Process.ProcessName + ".exe" with
+        // whatever casing Windows reports, and the allowlist is hand-typed in the editor. Comparing
+        // through the set's comparer keeps casing in one place instead of at each use site.
+        var allow = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var a in args)
             foreach (var part in a.Split(',', ' ', ';'))
-                if (part.Trim().Length > 0) allow.Add(part.Trim().ToLowerInvariant());
+                if (part.Trim().Length > 0) allow.Add(part.Trim());
         if (allow.Count == 0) {
-            allow.Add("zoom.exe"); allow.Add("teams.exe"); allow.Add("ms-teams.exe");
+            allow.Add("Zoom.exe"); allow.Add("Teams.exe"); allow.Add("ms-teams.exe");
         }
 
         // No synthetic idle baseline: the parent starts from a known-idle recorder, and emitting
         // {"active":false} here read as a call-ended transition — respawning the monitor during a
         // meeting stopped the recording in progress and split it into a new file. The first poll
         // below reports an already-active call within one second anyway.
-        bool lastActive = false; string lastApp = null;
+        //
+        // The transition test compares the whole SET, not just the first match. Watching only the
+        // first match loses the case this exists for: with Discord already holding the mic, Teams
+        // joining a call leaves the first match unchanged, nothing would be emitted, and the recorder
+        // would never learn a meeting had started.
+        bool lastActive = false;
+        var lastApps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         while (true) {
-            string app = null;
-            try { app = ActiveAllowlistedApp(allow); } catch { app = null; }
-            bool active = app != null;
-            if (active != lastActive || (active && app != lastApp)) {
-                if (!Emit(active, app)) return 0;   // parent pipe gone -> exit quietly
-                lastActive = active; lastApp = app;
+            List<string> apps;
+            try { apps = ActiveAllowlistedApps(allow); } catch { apps = new List<string>(); }
+            bool active = apps.Count > 0;
+            var now = new HashSet<string>(apps, StringComparer.OrdinalIgnoreCase);
+            if (active != lastActive || !now.SetEquals(lastApps)) {
+                if (!Emit(active, apps)) return 0;   // parent pipe gone -> exit quietly
+                lastActive = active; lastApps = now;
             }
             Thread.Sleep(1000);
         }
     }
 
     // Returns false if the stdout pipe is broken (parent process exited) so the caller can stop.
-    static bool Emit(bool active, string app) {
+    static bool Emit(bool active, List<string> apps) {
         try {
-            string line = active
-                ? "{\"active\":true,\"app\":\"" + JsonEscape(app) + "\"}"
-                : "{\"active\":false}";
-            Console.Out.WriteLine(line);
+            var sb = new System.Text.StringBuilder();
+            sb.Append("{\"active\":").Append(active ? "true" : "false");
+            if (active) sb.Append(",\"app\":\"").Append(JsonEscape(apps[0])).Append("\"");
+            sb.Append(",\"apps\":[");
+            for (int i = 0; i < apps.Count; i++) {
+                if (i > 0) sb.Append(",");
+                sb.Append("\"").Append(JsonEscape(apps[i])).Append("\"");
+            }
+            sb.Append("]}");
+            Console.Out.WriteLine(sb.ToString());
             Console.Out.Flush();
             return true;
         } catch { return false; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "open-quake",
-  "version": "0.6.8",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-quake",
-      "version": "0.6.8",
+      "version": "0.8.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@jitsi/robotjs": "^0.6.22",
         "adm-zip": "^0.6.0",
         "emojilib": "^4.0.3",
+        "mqtt": "^5.15.2",
         "node-hid": "^3.3.0",
         "obs-websocket-js": "^5.0.8",
         "win-ca": "^3.5.1",
@@ -24,6 +25,15 @@
       },
       "engines": {
         "node": ">=18 <25"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
@@ -579,10 +589,18 @@
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -590,6 +608,15 @@
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -613,6 +640,18 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/adm-zip": {
@@ -941,7 +980,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -957,6 +995,63 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/bl/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
@@ -987,11 +1082,46 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/broker-factory": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.15.tgz",
+      "integrity": "sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/builder-util": {
@@ -1228,6 +1358,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
+    },
     "node_modules/compare-version": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
@@ -1244,6 +1380,35 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -1778,11 +1943,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -1797,6 +1980,19 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -2188,6 +2384,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -2250,6 +2452,26 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2266,8 +2488,16 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-electron": {
       "version": "2.2.2",
@@ -2337,6 +2567,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/js-yaml": {
@@ -2559,7 +2799,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2600,6 +2839,100 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mqtt": {
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.2.tgz",
+      "integrity": "sha512-VWZU2CSUY3U3oN0PSBRDE5SNsFi4zqqNeQ/uv3pZWqY3CrBXD/dhd0ZLjlsk5YnebGlrapi4lRVNJPUNQ5aZ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mqtt/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/ms": {
@@ -2779,6 +3112,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
       }
     },
     "node_modules/object-keys": {
@@ -3024,11 +3367,19 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -3207,6 +3558,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -3245,7 +3602,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -3349,6 +3705,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+      "integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3382,6 +3762,15 @@
         "node": "*"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -3404,7 +3793,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -3578,7 +3966,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-fest": {
@@ -3595,6 +3982,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
@@ -3610,7 +4003,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -3663,7 +4055,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/webcrypto-core": {
@@ -3707,6 +4098,53 @@
         "make-dir": "^1.3.0",
         "node-forge": "^1.2.1",
         "split": "^1.0.1"
+      }
+    },
+    "node_modules/worker-factory": {
+      "version": "7.0.50",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.50.tgz",
+      "integrity": "sha512-hhwc0G+sFwM4qBuhJIUBn2p1Jf8v/FwmLUANBf/Q+Lt2uI8mfIZQhXaZQACodQD4R7Zp6cn/6702bIvNn2puJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.34",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.34.tgz",
+      "integrity": "sha512-WXL+Dqsm0G6dnC66rQsvM3tPT2adhbqSirWUCZGglkALOr8ocS0KlpU0iuKbjflJOlu3ydZikMEVrYnHOM9suw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.18",
+        "worker-timers-worker": "^9.0.15"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.18",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.18.tgz",
+      "integrity": "sha512-FrjzDVX1wKfZN0gRbCFqv8VHuTncG4sbI/WGEg4tSSQeIsnwqg4YBYWMAHYLJtUDEYYmiK65UKFrVMVk2irDSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "broker-factory": "^3.1.15",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.15"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.15.tgz",
+      "integrity": "sha512-KKUe7lZ/Aignr51H6hOUik8LwTnIgojH/1lwhli8A8qIEIyewogZTpNpMW5B6BF7nmwBOkUoTYgf1H3QShcjSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@jitsi/robotjs": "^0.6.22",
     "adm-zip": "^0.6.0",
     "emojilib": "^4.0.3",
+    "mqtt": "^5.15.2",
     "node-hid": "^3.3.0",
     "obs-websocket-js": "^5.0.8",
     "win-ca": "^3.5.1",

--- a/test/busySchedule.test.js
+++ b/test/busySchedule.test.js
@@ -1,0 +1,109 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { isActive, describe: describeSched, toMinutes, parseDays } = require('../app/busySchedule');
+
+// 2026-09-07 is a Monday, so +n days walks the week predictably.
+const MON = 1, TUE = 2, FRI = 5, SAT = 6, SUN = 0;
+function at(dayOffset, hhmm) {
+  const [h, m] = hhmm.split(':').map(Number);
+  return new Date(2026, 8, 7 + dayOffset, h, m, 0);
+}
+const WEEKDAYS = { enabled: true, days: '1,2,3,4,5', start: '08:00', end: '17:00' };
+
+test('toMinutes parses valid times and rejects nonsense', () => {
+  assert.strictEqual(toMinutes('08:30'), 510);
+  assert.strictEqual(toMinutes('00:00'), 0);
+  assert.strictEqual(toMinutes('23:59'), 1439);
+  assert.strictEqual(toMinutes('24:00'), null);
+  assert.strictEqual(toMinutes('8:5'), null);
+  assert.strictEqual(toMinutes(''), null);
+  assert.strictEqual(toMinutes(null), null);
+});
+
+test('parseDays tolerates spacing and ignores out-of-range values', () => {
+  assert.deepStrictEqual([...parseDays('1,2, 3')], [1, 2, 3]);
+  assert.deepStrictEqual([...parseDays('0,6')], [0, 6]);
+  assert.deepStrictEqual([...parseDays('7,-1,x')], []);
+});
+
+test('a disabled schedule is always active', () => {
+  assert.strictEqual(isActive(at(SAT, '03:00'), { enabled: false, days: '', start: '', end: '' }), true);
+});
+
+test('inside and outside the weekday window', () => {
+  assert.strictEqual(isActive(at(0, '09:00'), WEEKDAYS), true, 'Monday morning');
+  assert.strictEqual(isActive(at(0, '07:59'), WEEKDAYS), false, 'just before start');
+  assert.strictEqual(isActive(at(0, '08:00'), WEEKDAYS), true, 'start is inclusive');
+  assert.strictEqual(isActive(at(0, '16:59'), WEEKDAYS), true, 'just before end');
+  assert.strictEqual(isActive(at(0, '17:00'), WEEKDAYS), false, 'end is exclusive');
+});
+
+test('an unticked day is never active', () => {
+  assert.strictEqual(isActive(at(5, '09:00'), WEEKDAYS), false, 'Saturday');
+  assert.strictEqual(isActive(at(6, '09:00'), WEEKDAYS), false, 'Sunday');
+});
+
+test('OVERNIGHT: a window that wraps midnight works in both halves', () => {
+  // The classic bug: start <= now < end is false for every minute of a wrapped window, so the light
+  // works only during the hours you deliberately excluded.
+  const night = { enabled: true, days: '1,2,3,4,5', start: '22:00', end: '06:00' };
+  assert.strictEqual(isActive(at(0, '22:30'), night), true, 'Monday evening');
+  assert.strictEqual(isActive(at(0, '23:59'), night), true);
+  assert.strictEqual(isActive(at(1, '01:00'), night), true, 'Tuesday small hours, from Monday window');
+  assert.strictEqual(isActive(at(1, '05:59'), night), true);
+  assert.strictEqual(isActive(at(1, '06:00'), night), false, 'end is exclusive');
+  assert.strictEqual(isActive(at(1, '12:00'), night), false, 'midday is outside');
+});
+
+test('OVERNIGHT: the tail belongs to the day the window STARTED', () => {
+  // Friday 22:00-06:00 ticked, Saturday NOT ticked. 01:00 Saturday is still Friday's window.
+  const fri = { enabled: true, days: '5', start: '22:00', end: '06:00' };
+  assert.strictEqual(isActive(at(4, '23:00'), fri), true, 'Friday night');
+  assert.strictEqual(isActive(at(5, '01:00'), fri), true, "Saturday 1am is Friday's tail");
+  assert.strictEqual(isActive(at(5, '23:00'), fri), false, 'Saturday night is not ticked');
+  // And the converse: Saturday ticked must NOT light up on Saturday morning from an unticked Friday.
+  const sat = { enabled: true, days: '6', start: '22:00', end: '06:00' };
+  assert.strictEqual(isActive(at(5, '01:00'), sat), false, 'Saturday 1am belongs to Friday');
+  assert.strictEqual(isActive(at(5, '23:00'), sat), true);
+});
+
+test('per-day times override the shared pair, and only for the days that have one', () => {
+  const s = {
+    enabled: true, days: '1,2,3,4,5', start: '08:00', end: '17:00', perDay: true,
+    times: { 1: { s: '06:00', e: '10:00' }, 5: { s: '08:00', e: '12:00' } },
+  };
+  assert.strictEqual(isActive(at(0, '07:00'), s), true, 'Monday uses its own early start');
+  assert.strictEqual(isActive(at(0, '11:00'), s), false, 'and its own early end');
+  assert.strictEqual(isActive(at(1, '09:00'), s), true, 'Tuesday falls back to the shared window');
+  assert.strictEqual(isActive(at(1, '07:00'), s), false);
+  assert.strictEqual(isActive(at(4, '11:00'), s), true, 'Friday uses its own');
+  assert.strictEqual(isActive(at(4, '13:00'), s), false);
+});
+
+test('per-day times are ignored when the per-day switch is off', () => {
+  const s = { enabled: true, days: '1', start: '08:00', end: '17:00', perDay: false,
+    times: { 1: { s: '06:00', e: '07:00' } } };
+  assert.strictEqual(isActive(at(0, '06:30'), s), false, 'stale per-day data must not leak in');
+  assert.strictEqual(isActive(at(0, '09:00'), s), true);
+});
+
+test('a broken time FAILS OPEN rather than disabling the light', () => {
+  // A light that mysteriously never comes on is far worse to diagnose than one that shows outside
+  // hours, so an unparseable time is treated as no restriction.
+  const s = { enabled: true, days: '1,2,3,4,5', start: 'nonsense', end: '17:00' };
+  assert.strictEqual(isActive(at(0, '03:00'), s), true);
+});
+
+test('but an explicitly empty day list means never, not always', () => {
+  // The user actively unticked every day. That is an instruction, not a broken value.
+  assert.strictEqual(isActive(at(0, '09:00'), { enabled: true, days: '', start: '08:00', end: '17:00' }), false);
+});
+
+test('describe summarises what was configured', () => {
+  assert.strictEqual(describeSched({ enabled: false }), 'Always active');
+  assert.strictEqual(describeSched(WEEKDAYS), 'Mon, Tue, Wed, Thu, Fri 08:00–17:00');
+  assert.match(describeSched({ enabled: true, days: '1', start: '22:00', end: '06:00' }), /overnight/);
+  assert.match(describeSched({ enabled: true, days: '', start: '08:00', end: '17:00' }), /never come on/);
+  assert.match(describeSched({ enabled: true, days: '1', start: 'x', end: 'y' }), /always active/);
+});

--- a/test/busylightReport.test.js
+++ b/test/busylightReport.test.js
@@ -1,0 +1,172 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  buildReport, parseColor, createBusylightService,
+  KUANDO_VENDOR_ID, REPORT_LENGTH,
+} = require('../app/busylightService');
+
+// These assertions lock in a byte layout taken from a community reference implementation, NOT from
+// Kuando documentation. They prove the frame is internally consistent and stable across edits; they
+// cannot prove the device agrees. Real hardware is what settles that — see the Test light button.
+// If the offsets turn out to be wrong, these expectations move together with buildReport().
+
+test('report is 65 bytes with report id 0 and the protocol step', () => {
+  const buf = buildReport({ r: 0, g: 0, b: 0 });
+  assert.strictEqual(buf.length, REPORT_LENGTH);
+  assert.strictEqual(buf.length, 65);
+  assert.strictEqual(buf[0], 0, 'leading report id for the Windows node-hid write path');
+  assert.strictEqual(buf[1], 0x10);
+});
+
+test('RGB lands at 3,4,5 in that order', () => {
+  const buf = buildReport({ r: 0x11, g: 0x22, b: 0x33 });
+  assert.strictEqual(buf[3], 0x11);
+  assert.strictEqual(buf[4], 0x22);
+  assert.strictEqual(buf[5], 0x33);
+});
+
+test('steady, not blinking, and silent', () => {
+  const buf = buildReport({ r: 255, g: 0, b: 0 });
+  assert.strictEqual(buf[6], 0, 'on time 0 = steady');
+  assert.strictEqual(buf[7], 0, 'off time 0 = steady');
+  assert.strictEqual(buf[8], 0x80, 'silence, deliberately — not a forgotten placeholder');
+});
+
+test('the fixed tail the device checks is present', () => {
+  const buf = buildReport({ r: 1, g: 2, b: 3 });
+  assert.deepStrictEqual(buf.slice(57, 63), [0xff, 0xff, 0xff, 0xff, 0x06, 0x93]);
+});
+
+test('checksum is the big-endian sum of bytes 0..62', () => {
+  const buf = buildReport({ r: 0x10, g: 0x20, b: 0x30 });
+  let sum = 0;
+  for (let i = 0; i <= 62; i++) sum += buf[i];
+  assert.strictEqual(buf[63], (sum >> 8) & 0xff, 'high byte first');
+  assert.strictEqual(buf[64], sum & 0xff);
+  // Spot-check the arithmetic independently of the loop above so a bug in both cannot cancel out.
+  // step 0x10=16, rgb 16+32+48, tone 0x80=128, tail 4*255=1020 + 6 + 147  ->  1413 = 0x585
+  assert.strictEqual(16 + 16 + 32 + 48 + 128 + 1020 + 6 + 147, 1413, 'the arithmetic itself');
+  assert.strictEqual((buf[63] << 8) | buf[64], 1413);
+  assert.strictEqual(buf[63], 0x05);
+  assert.strictEqual(buf[64], 0x85);
+});
+
+test('every byte is a valid uint8', () => {
+  const buf = buildReport({ r: 999, g: -5, b: 12.7 });
+  buf.forEach((b, i) => {
+    assert.ok(Number.isInteger(b) && b >= 0 && b <= 255, 'byte ' + i + ' out of range: ' + b);
+  });
+  assert.strictEqual(buf[3], 255, 'clamped high');
+  assert.strictEqual(buf[4], 0, 'clamped low');
+  assert.strictEqual(buf[5], 13, 'rounded');
+});
+
+test('a missing colour yields a valid black frame rather than throwing', () => {
+  const buf = buildReport();
+  assert.strictEqual(buf.length, 65);
+  assert.deepStrictEqual(buf.slice(3, 6), [0, 0, 0]);
+});
+
+test('the off frame is black but otherwise well-formed', () => {
+  const off = buildReport({ r: 0, g: 0, b: 0 });
+  assert.deepStrictEqual(off.slice(3, 6), [0, 0, 0]);
+  assert.deepStrictEqual(off.slice(57, 63), [0xff, 0xff, 0xff, 0xff, 0x06, 0x93]);
+  assert.strictEqual((off[63] << 8) | off[64], 0x10 + 0x80 + 0xff * 4 + 0x06 + 0x93);
+});
+
+test('parseColor handles 6-digit, 3-digit, and a leading hash', () => {
+  assert.deepStrictEqual(parseColor('#ff0000'), { r: 255, g: 0, b: 0 });
+  assert.deepStrictEqual(parseColor('00ff00'), { r: 0, g: 255, b: 0 });
+  assert.deepStrictEqual(parseColor('#f00'), { r: 255, g: 0, b: 0 });
+});
+
+test('parseColor scales by brightness', () => {
+  assert.deepStrictEqual(parseColor('#ff0000', 50), { r: 128, g: 0, b: 0 });
+  assert.deepStrictEqual(parseColor('#ffffff', 0), { r: 0, g: 0, b: 0 });
+  assert.deepStrictEqual(parseColor('#ff0000', 300), { r: 255, g: 0, b: 0 }, 'clamped to 100%');
+});
+
+test('a mistyped colour goes black instead of throwing', () => {
+  // A bad value in settings must not be able to take down the presence fan-out.
+  assert.deepStrictEqual(parseColor('nonsense'), { r: 0, g: 0, b: 0 });
+  assert.deepStrictEqual(parseColor(''), { r: 0, g: 0, b: 0 });
+  assert.deepStrictEqual(parseColor(null), { r: 0, g: 0, b: 0 });
+});
+
+// ---- service behaviour, against a fake HID ----
+
+function fakeHid(opts) {
+  const o = opts || {};
+  const writes = [];
+  const devices = o.devices || [{ vendorId: KUANDO_VENDOR_ID, productId: 0x3bcd, product: 'Busylight UC omega', path: 'fake:1' }];
+  let openCount = 0;
+  function HIDDevice() {
+    openCount++;
+    if (o.openThrows) throw new Error(o.openThrows);
+    this.write = buf => {
+      if (o.writeThrowsAfter != null && writes.length >= o.writeThrowsAfter) throw new Error('device gone');
+      writes.push(buf);
+      return buf.length;
+    };
+    this.close = () => {};
+  }
+  return { devices: () => devices, HID: HIDDevice, _writes: writes, _openCount: () => openCount };
+}
+
+test('setColor writes a frame carrying the requested colour', () => {
+  const hid = fakeHid();
+  const svc = createBusylightService({ hid });
+  assert.strictEqual(svc.setColor({ r: 255, g: 0, b: 0 }), true);
+  assert.strictEqual(hid._writes.length, 1);
+  assert.deepStrictEqual(hid._writes[0].slice(3, 6), [255, 0, 0]);
+  svc.close();
+});
+
+test('no Kuando device present reports a clear failure rather than throwing', () => {
+  const hid = fakeHid({ devices: [{ vendorId: 0x1234, productId: 1, product: 'Something else' }] });
+  const svc = createBusylightService({ hid });
+  assert.strictEqual(svc.setColor({ r: 255, g: 0, b: 0 }), false);
+  assert.strictEqual(svc.isConnected(), false);
+  assert.strictEqual(svc.detect().found, false);
+  assert.match(svc.status().error, /no Kuando Busylight found/);
+});
+
+test('a device held by other software names Kuando in the error', () => {
+  // The single most likely support question; the raw HID message alone is useless.
+  const hid = fakeHid({ openThrows: 'cannot open device' });
+  const svc = createBusylightService({ hid });
+  assert.strictEqual(svc.setColor({ r: 255, g: 0, b: 0 }), false);
+  assert.match(svc.status().error, /Kuando Busylight for UC/);
+});
+
+test('a failed write drops the handle so the next call re-detects', () => {
+  // Without this an unplug means the light never works again until a restart.
+  const hid = fakeHid({ writeThrowsAfter: 1 });
+  const svc = createBusylightService({ hid });
+  assert.strictEqual(svc.setColor({ r: 255, g: 0, b: 0 }), true);
+  assert.strictEqual(svc.isConnected(), true);
+  assert.strictEqual(svc.setColor({ r: 0, g: 255, b: 0 }), false);
+  assert.strictEqual(svc.isConnected(), false, 'handle released');
+  assert.strictEqual(hid._openCount(), 1);
+  svc.setColor({ r: 0, g: 0, b: 255 });
+  assert.strictEqual(hid._openCount(), 2, 're-opened rather than writing to a dead handle');
+});
+
+test('detect finds the light by vendor id whatever the product id', () => {
+  // Omega is 0x3BCD; Alpha and the older UC models differ. Vendor matching keeps them all working.
+  const hid = fakeHid({ devices: [{ vendorId: KUANDO_VENDOR_ID, productId: 0x3bca, product: 'Busylight Alpha', path: 'fake:2' }] });
+  const svc = createBusylightService({ hid });
+  const found = svc.detect();
+  assert.strictEqual(found.found, true);
+  assert.strictEqual(found.product, 'Busylight Alpha');
+});
+
+test('close writes black so quitting does not leave you showing busy', () => {
+  const hid = fakeHid();
+  const svc = createBusylightService({ hid });
+  svc.setColor({ r: 255, g: 0, b: 0 });
+  svc.close();
+  assert.deepStrictEqual(hid._writes[hid._writes.length - 1].slice(3, 6), [0, 0, 0]);
+  assert.strictEqual(svc.isConnected(), false);
+});

--- a/test/meetingDefaultsSync.test.js
+++ b/test/meetingDefaultsSync.test.js
@@ -1,0 +1,112 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+// The meeting settings defaults are written out TWICE by design: MEETING_DEFAULTS in app/main.js (the
+// runtime source of truth) and currentMe() in app/config.js (the editor's copy, which cannot require
+// a main-process module). Nothing enforces that by construction, and the failure is quiet in both
+// directions:
+//
+//   key only in main.js   -> the editor drops it on every save, because currentMe() rebuilds the whole
+//                            meeting object from its own defaults. The user's value silently reverts.
+//   key only in config.js -> main never reads it, so the control saves and persists and does nothing.
+//
+// Neither throws, neither logs. This test is the only thing standing between a new setting and one of
+// those two outcomes, so it compares the key sets directly rather than trusting review.
+
+function readKeys(file, startMarker) {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'app', file), 'utf8');
+  const start = src.indexOf(startMarker);
+  assert.notStrictEqual(start, -1, 'could not find ' + startMarker + ' in ' + file +
+    ' — if it was renamed, update this test rather than deleting it');
+  // Walk to the end of the object literal, tracking depth so a nested object cannot end it early.
+  const open = src.indexOf('{', start);
+  let depth = 0, end = -1;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  assert.notStrictEqual(end, -1, 'unbalanced literal in ' + file);
+  const body = src.slice(open + 1, end);
+  // Top-level keys only: skip anything nested (there is none today, but be strict rather than lucky).
+  const keys = new Set();
+  let d = 0;
+  body.replace(/\{|\}|([A-Za-z_$][\w$]*)\s*:/g, (m, key, offset) => {
+    if (m === '{') d++;
+    else if (m === '}') d--;
+    else if (key && d === 0) {
+      // Only count a key if it is at the start of an entry, not part of a value expression.
+      const before = body.slice(0, offset).replace(/\s+$/, '');
+      if (before === '' || before.endsWith(',')) keys.add(key);
+    }
+    return m;
+  });
+  return keys;
+}
+
+test('MEETING_DEFAULTS and the editor currentMe() defaults declare the same keys', () => {
+  const main = readKeys('main.js', 'const MEETING_DEFAULTS =');
+  const editor = readKeys('config.js', 'const currentMe = ()');
+
+  assert.ok(main.size > 20, 'sanity: parsed ' + main.size + ' keys from main.js');
+  assert.ok(editor.size > 20, 'sanity: parsed ' + editor.size + ' keys from config.js');
+
+  const missingInEditor = [...main].filter(k => !editor.has(k));
+  const missingInMain = [...editor].filter(k => !main.has(k));
+
+  assert.deepStrictEqual(missingInEditor, [],
+    'keys in MEETING_DEFAULTS but not in currentMe(): the editor will silently revert these on save');
+  assert.deepStrictEqual(missingInMain, [],
+    'keys in currentMe() but not in MEETING_DEFAULTS: these save but nothing ever reads them');
+});
+
+test('every busy-presence key is present in both', () => {
+  // Named explicitly so a partial paste of this feature fails loudly rather than half-working.
+  const expected = [
+    'busyEnabled', 'busyApps', 'busyOnRecording', 'busyOffDelaySec',
+    'busyLightEnabled', 'busyLightBusyColor', 'busyLightFreeColor', 'busyLightBrightness',
+    'busyLightFreeOff', 'busyManualColor', 'busyWledEnabled', 'busyWledHost',
+    'busyMqttEnabled', 'busyMqttUrl', 'busyMqttUser', 'busyMqttPassword', 'busyMqttBaseTopic',
+  ];
+  const main = readKeys('main.js', 'const MEETING_DEFAULTS =');
+  const editor = readKeys('config.js', 'const currentMe = ()');
+  expected.forEach(k => {
+    assert.ok(main.has(k), 'MEETING_DEFAULTS is missing ' + k);
+    assert.ok(editor.has(k), 'currentMe() is missing ' + k);
+  });
+});
+
+test('the MQTT password is registered for encryption at rest', () => {
+  // A secret missing from secretStore is written to config.json in cleartext, and the app behaves
+  // identically either way — no test that exercises behaviour can catch it.
+  const src = fs.readFileSync(path.join(__dirname, '..', 'app', 'secretStore.js'), 'utf8');
+  assert.match(src, /busyMqttPassword/,
+    'busyMqttPassword must be listed in transformSettingsSecrets or it ships in cleartext');
+});
+
+// The JS test suite drives CAPTURED monitor output, so it can pass in full while the C# helper that
+// produces that output has silently reverted to the single-app version — which is exactly what
+// happened during development, via a stray `git checkout main -- .`. Nothing else in the tree notices.
+// These assertions are the only link between the JS contract and the native source it depends on.
+test('the native monitor still emits every matching app, not just the first', () => {
+  const cs = fs.readFileSync(path.join(__dirname, '..', 'native', 'mic-session-monitor.cs'), 'utf8');
+
+  assert.match(cs, /static List<string> ActiveAllowlistedApps\(/,
+    'the helper must collect ALL matches; a `static string ActiveAllowlistedApp(` signature means it ' +
+    'reverted to returning the first hit, and auto-record silently breaks when a busy-only app holds the mic');
+
+  assert.doesNotMatch(cs, /allow\.Contains\(name\.ToLowerInvariant\(\)\)\) return name;/,
+    'returning on the first allowlisted match is the original bug');
+
+  assert.match(cs, /SetEquals\(lastApps\)/,
+    'the transition test must compare the whole set — comparing only the first match means a call app ' +
+    'joining an already-busy mic emits nothing at all');
+
+  assert.match(cs, /StringComparer\.OrdinalIgnoreCase/,
+    'app-name matching must be case-insensitive at the set, not at each use site');
+
+  assert.match(cs, /"apps"/,
+    'the emitted JSON must carry the apps array the JS routing reads');
+});

--- a/test/micMonitorRouting.test.js
+++ b/test/micMonitorRouting.test.js
@@ -1,0 +1,99 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { parseAppList, monitorAllowlist, routeMonitorMessage } = require('../app/micMonitorRouting');
+
+const RECORD = parseAppList('Zoom.exe,Teams.exe,ms-teams.exe');
+const BUSY = parseAppList('Zoom.exe,Teams.exe,ms-teams.exe,Discord.exe,slack.exe');
+
+test('parseAppList splits on commas, spaces and semicolons and lowercases', () => {
+  assert.deepStrictEqual([...parseAppList('Zoom.exe, Teams.exe;ms-teams.exe')],
+    ['zoom.exe', 'teams.exe', 'ms-teams.exe']);
+  assert.deepStrictEqual([...parseAppList('')], []);
+  assert.deepStrictEqual([...parseAppList(null)], []);
+});
+
+test('sloppy spacing around separators still matches the monitor output', () => {
+  // 'Teams.exe , Discord.exe' typed in the settings field must not yield ' Discord.exe', which
+  // would lowercase fine and then never match a name the monitor reports.
+  const set = parseAppList('Teams.exe , Discord.exe ,, slack.exe');
+  assert.deepStrictEqual([...set], ['teams.exe', 'discord.exe', 'slack.exe']);
+  const r = routeMonitorMessage({ active: true, apps: ['Discord.exe'] }, RECORD, set);
+  assert.strictEqual(r.busyActive, true);
+  assert.strictEqual(monitorAllowlist('Zoom.exe , Teams.exe', ' Discord.exe ', true),
+    'Zoom.exe,Teams.exe,Discord.exe');
+});
+
+test('monitorAllowlist is unchanged from the record list when busy is disabled', () => {
+  // Guards the promise that enabling nothing leaves auto-record byte-identical to today.
+  assert.strictEqual(monitorAllowlist('Zoom.exe,Teams.exe', 'Discord.exe', false), 'Zoom.exe,Teams.exe');
+});
+
+test('monitorAllowlist unions both lists, record apps first, de-duplicated case-insensitively', () => {
+  assert.strictEqual(
+    monitorAllowlist('Zoom.exe,Teams.exe', 'teams.exe,Discord.exe', true),
+    'Zoom.exe,Teams.exe,Discord.exe');
+});
+
+test('a busy-only app in the union does not trigger the recorder', () => {
+  const r = routeMonitorMessage({ active: true, app: 'Discord.exe', apps: ['Discord.exe'] }, RECORD, BUSY);
+  assert.strictEqual(r.recordApp, null);
+  assert.strictEqual(r.busyActive, true);
+});
+
+test('REGRESSION: Teams starting while Discord holds the mic still triggers the recorder', () => {
+  // The original bug. msg.app stays Discord.exe because endpoint enumeration reached it first, so
+  // anything reading msg.app would ignore the Teams call entirely.
+  const msg = { active: true, app: 'Discord.exe', apps: ['Discord.exe', 'Teams.exe'] };
+  const r = routeMonitorMessage(msg, RECORD, BUSY);
+  assert.strictEqual(msg.app, 'Discord.exe', 'precondition: the compat field is the wrong app');
+  assert.strictEqual(r.recordApp, 'Teams.exe');
+  assert.strictEqual(r.busyActive, true);
+});
+
+test('REGRESSION: Teams ending while Discord still holds the mic stops the recorder', () => {
+  // active stays true because Discord is still capturing. Auto-stop must key off recordApp, not
+  // active, or the recording runs until the silence timer.
+  const msg = { active: true, app: 'Discord.exe', apps: ['Discord.exe'] };
+  const r = routeMonitorMessage(msg, RECORD, BUSY);
+  assert.strictEqual(msg.active, true, 'precondition: the top-level flag is still true');
+  assert.strictEqual(r.recordApp, null, 'recorder must see no trigger app');
+  assert.strictEqual(r.busyActive, true, 'busy light stays on for Discord');
+});
+
+test('idle clears both consumers', () => {
+  const r = routeMonitorMessage({ active: false, apps: [] }, RECORD, BUSY);
+  assert.deepStrictEqual(r.apps, []);
+  assert.strictEqual(r.recordApp, null);
+  assert.strictEqual(r.busyActive, false);
+});
+
+test('matching ignores case', () => {
+  const r = routeMonitorMessage({ active: true, apps: ['TEAMS.EXE'] }, RECORD, BUSY);
+  assert.strictEqual(r.recordApp, 'TEAMS.EXE');
+  assert.strictEqual(r.busyActive, true);
+});
+
+test('a stale monitor without apps[] still drives the recorder', () => {
+  // A packaged install mid-upgrade could run an older exe. Reporting idle there would silently kill
+  // auto-record, so the single-app form is honoured.
+  const r = routeMonitorMessage({ active: true, app: 'Teams.exe' }, RECORD, BUSY);
+  assert.strictEqual(r.recordApp, 'Teams.exe');
+  assert.strictEqual(r.busyActive, true);
+
+  const idle = routeMonitorMessage({ active: false }, RECORD, BUSY);
+  assert.strictEqual(idle.recordApp, null);
+  assert.strictEqual(idle.busyActive, false);
+});
+
+test('junk entries are ignored rather than thrown on', () => {
+  const r = routeMonitorMessage({ active: true, apps: ['', null, '  ', 'Teams.exe'] }, RECORD, BUSY);
+  assert.deepStrictEqual(r.apps, ['Teams.exe']);
+  assert.strictEqual(r.recordApp, 'Teams.exe');
+});
+
+test('an empty busy list never reports busy', () => {
+  const r = routeMonitorMessage({ active: true, apps: ['Teams.exe'] }, RECORD, parseAppList(''));
+  assert.strictEqual(r.recordApp, 'Teams.exe');
+  assert.strictEqual(r.busyActive, false);
+});

--- a/test/presence.test.js
+++ b/test/presence.test.js
@@ -1,0 +1,198 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { createPresence } = require('../app/presence');
+
+// A controllable clock: evaluate() only ever asks for now(), so advancing this and calling tick()
+// reproduces exactly what presenceService's timer does, with no sleeping.
+function clock(start) {
+  let t = start || 1000;
+  return { now: () => t, advance: ms => { t += ms; } };
+}
+
+test('a call makes you busy immediately, with the app name', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  assert.strictEqual(p.getState().busy, false);
+  p.setCall(true, 'Teams.exe');
+  const s = p.getState();
+  assert.strictEqual(s.busy, true);
+  assert.strictEqual(s.reason, 'call');
+  assert.strictEqual(s.app, 'Teams.exe');
+  assert.strictEqual(s.since, 1000);
+});
+
+test('going free waits for the off-delay', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  p.setCall(true, 'Teams.exe');
+  assert.strictEqual(p.setCall(false, null), true, 'an off-delay should be pending');
+  assert.strictEqual(p.getState().busy, true, 'still busy during the delay');
+
+  c.advance(4999);
+  assert.strictEqual(p.tick(), true);
+  assert.strictEqual(p.getState().busy, true);
+
+  c.advance(1);
+  assert.strictEqual(p.tick(), false);
+  assert.strictEqual(p.getState().busy, false);
+});
+
+test('a mid-meeting mic blip never reaches the light', () => {
+  // The reason the debounce exists: Teams drops and retakes the mic when the meeting window changes.
+  const c = clock();
+  const changes = [];
+  const p = createPresence({ now: c.now, offDelayMs: 5000, onChange: s => changes.push(s.busy) });
+  p.setCall(true, 'Teams.exe');
+  c.advance(60000);
+  p.setCall(false, null);      // blip starts
+  c.advance(800);
+  p.tick();
+  p.setCall(true, 'Teams.exe');  // mic retaken well inside the delay
+  c.advance(60000);
+  p.tick();
+  assert.strictEqual(p.getState().busy, true);
+  assert.deepStrictEqual(changes, [true], 'exactly one transition: one continuous busy span');
+});
+
+test('recording alone makes you busy and outranks a call', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  p.setRecording(true);
+  assert.strictEqual(p.getState().reason, 'recording');
+  p.setCall(true, 'Zoom.exe');
+  assert.strictEqual(p.getState().reason, 'recording', 'recording outranks call');
+  p.setRecording(false);
+  assert.strictEqual(p.getState().reason, 'call', 'falls back to the still-live call');
+  assert.strictEqual(p.getState().busy, true);
+});
+
+test('recording keeps you busy after the call app releases the mic', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  p.setCall(true, 'Teams.exe');
+  p.setRecording(true);
+  p.setCall(false, null);
+  c.advance(60000);
+  p.tick();
+  assert.strictEqual(p.getState().busy, true, 'a manual recording outlives the call');
+  assert.strictEqual(p.getState().reason, 'recording');
+});
+
+test('busyOnRecording off stops recording from counting', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 0, busyOnRecording: false });
+  p.setRecording(true);
+  assert.strictEqual(p.getState().busy, false);
+  p.setRecordingCounts(true);
+  assert.strictEqual(p.getState().busy, true);
+});
+
+test('a busy override wins over every input, including none', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  p.setOverride('busy');
+  assert.strictEqual(p.getState().busy, true);
+  assert.strictEqual(p.getState().reason, 'manual');
+  assert.strictEqual(p.getState().app, null, 'a manual busy is not attributed to an app');
+  p.setCall(true, 'Teams.exe');
+  assert.strictEqual(p.getState().reason, 'manual', 'override still wins while a call runs');
+});
+
+test('a free override wins over a live call and applies at once', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  p.setCall(true, 'Teams.exe');
+  p.setRecording(true);
+  assert.strictEqual(p.setOverride('free'), false, 'no debounce on a deliberate act');
+  assert.strictEqual(p.getState().busy, false);
+});
+
+test('returning to auto restores whatever the inputs still say', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  p.setCall(true, 'Teams.exe');
+  p.setOverride('free');
+  assert.strictEqual(p.getState().busy, false);
+  p.setOverride('auto');
+  assert.strictEqual(p.getState().busy, true, 'the call never went away');
+  assert.strictEqual(p.getState().reason, 'call');
+});
+
+test('an unknown override mode falls back to auto rather than pinning a state', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 0 });
+  p.setOverride('nonsense');
+  assert.strictEqual(p.getState().override, 'auto');
+});
+
+test('switching call apps re-emits so the panel can show the new one', () => {
+  const c = clock();
+  const seen = [];
+  const p = createPresence({ now: c.now, offDelayMs: 5000, onChange: s => seen.push(s.app) });
+  p.setCall(true, 'Teams.exe');
+  p.setCall(true, 'Zoom.exe');
+  assert.deepStrictEqual(seen, ['Teams.exe', 'Zoom.exe']);
+  assert.strictEqual(p.getState().since, 1000, 'one continuous busy span, not a restart');
+});
+
+test('a zero off-delay goes free immediately', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 0 });
+  p.setCall(true, 'Teams.exe');
+  assert.strictEqual(p.setCall(false, null), false);
+  assert.strictEqual(p.getState().busy, false);
+});
+
+test('a throwing onChange never breaks the state machine', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 0, onChange: () => { throw new Error('boom'); } });
+  assert.doesNotThrow(() => p.setCall(true, 'Teams.exe'));
+  assert.strictEqual(p.getState().busy, true);
+});
+
+test('custom is a distinct busy mode with its own reason', () => {
+  // 'custom' must not collapse into 'manual': the fan-out keys the user-picked colour off the reason,
+  // so if they were the same reason an ordinary manual busy would take the custom colour too.
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 0 });
+  p.setOverride('custom');
+  assert.strictEqual(p.getState().busy, true);
+  assert.strictEqual(p.getState().reason, 'custom');
+  p.setOverride('busy');
+  assert.strictEqual(p.getState().reason, 'manual');
+  p.setOverride('auto');
+  assert.strictEqual(p.getState().busy, false);
+});
+
+test('custom outranks a live call, like the other overrides', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 0 });
+  p.setCall(true, 'Teams.exe');
+  p.setOverride('custom');
+  assert.strictEqual(p.getState().reason, 'custom');
+  assert.strictEqual(p.getState().app, null, 'a deliberate state is not attributed to an app');
+});
+
+test('a recording ending goes free instantly — the debounce is only for mic blips', () => {
+  // The off-delay exists for a call app releasing and retaking the mic mid-meeting. A recording
+  // stopping is a discrete event from our own recorder; waiting on it just looks broken.
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  p.setRecording(true);
+  assert.strictEqual(p.getState().reason, 'recording');
+  assert.strictEqual(p.setRecording(false), false, 'no pending off-delay');
+  assert.strictEqual(p.getState().busy, false, 'free immediately');
+});
+
+test('but a call ending still waits, and a recording over a call still waits for the call', () => {
+  const c = clock();
+  const p = createPresence({ now: c.now, offDelayMs: 5000 });
+  p.setCall(true, 'Teams.exe');
+  p.setRecording(true);
+  p.setRecording(false);
+  assert.strictEqual(p.getState().busy, true, 'the call is still live');
+  assert.strictEqual(p.getState().reason, 'call');
+  assert.strictEqual(p.setCall(false, null), true, 'now the call debounce applies');
+  assert.strictEqual(p.getState().busy, true);
+});

--- a/test/presenceIntegration.test.js
+++ b/test/presenceIntegration.test.js
@@ -1,0 +1,120 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { parseAppList, monitorAllowlist, routeMonitorMessage } = require('../app/micMonitorRouting');
+const { createPresenceService } = require('../app/presenceService');
+
+// End-to-end through the real modules, driven by the EXACT stdout lines a real
+// mic-session-monitor.exe emitted on this machine. Only the three outputs are faked; the routing,
+// the state machine and the fan-out are the shipping code.
+//
+// The lines below are not invented. They were captured by running the rebuilt monitor against two
+// copies of ffmpeg holding the same physical microphone at once:
+//   {"active":true,"app":"discordish.exe","apps":["discordish.exe"]}
+//   {"active":true,"app":"discordish.exe","apps":["discordish.exe","teamsish.exe"]}
+//   {"active":true,"app":"discordish.exe","apps":["discordish.exe"]}
+// with "discordish" standing in for a busy-only app and "teamsish" for a recorded call app.
+
+function harness(settings) {
+  const events = { record: [], light: [], mqtt: [] };
+  const busylight = {
+    setColor: c => { events.light.push(c); return true; },
+    off: () => { events.light.push('off'); return true; },
+    close: () => {},
+    status: () => ({ connected: true, product: 'BUSYLIGHT OMEGA', error: null }),
+    isConnected: () => true,
+    detect: () => ({ found: true }),
+  };
+  const mqtt = {
+    apply: () => {},
+    publishState: s => { events.mqtt.push(s.busy ? 'ON' : 'OFF'); return true; },
+    status: () => ({ enabled: true, connected: true, error: null }),
+    stop: () => {},
+  };
+  const svc = createPresenceService({ busylight, mqtt, fetch: null });
+  svc.applySettings(Object.assign({
+    busyEnabled: true, busyLightEnabled: true, busyOffDelaySec: 0,
+    busyLightBusyColor: '#ff0000', busyLightFreeOff: true,
+    busyApps: 'teamsish.exe,discordish.exe', recordApps: 'teamsish.exe',
+  }, settings || {}));
+
+  // Mirrors startMicMonitor()'s handler in app/main.js.
+  const recordSet = parseAppList('teamsish.exe');
+  const busySet = parseAppList('teamsish.exe,discordish.exe');
+  const recorder = {
+    recording: false,
+    autoStart(app) { if (!this.recording) { this.recording = true; events.record.push('start:' + app); } },
+    autoStop(reason) { if (this.recording) { this.recording = false; events.record.push('stop:' + reason); } },
+  };
+  let firstLine = true;
+  function feed(line) {
+    const msg = JSON.parse(line);
+    const wasFirst = firstLine; firstLine = false;
+    const routed = routeMonitorMessage(msg, recordSet, busySet);
+    if (wasFirst && !msg.active) return;
+    if (routed.recordApp) recorder.autoStart(routed.recordApp);
+    else recorder.autoStop('call-ended');
+    svc.setCall(routed.busyActive, routed.busyActive ? (routed.recordApp || routed.apps[0] || null) : null);
+  }
+  return { feed, events, svc, recorder };
+}
+
+test('REAL CAPTURE: Discord idling, Teams joins and leaves — recorder and light both behave', () => {
+  const h = harness();
+
+  h.feed('{"active":true,"app":"discordish.exe","apps":["discordish.exe"]}');
+  assert.strictEqual(h.recorder.recording, false, 'a busy-only app must not start a recording');
+  assert.strictEqual(h.svc.getState().busy, true, 'but it does make you busy');
+  assert.deepStrictEqual(h.events.light[h.events.light.length - 1], { r: 255, g: 0, b: 0 });
+
+  h.feed('{"active":true,"app":"discordish.exe","apps":["discordish.exe","teamsish.exe"]}');
+  assert.strictEqual(h.recorder.recording, true, 'the call app joining MUST start the recording');
+  assert.deepStrictEqual(h.events.record, ['start:teamsish.exe']);
+
+  h.feed('{"active":true,"app":"discordish.exe","apps":["discordish.exe"]}');
+  assert.strictEqual(h.recorder.recording, false, 'the call ending MUST stop it, despite active:true');
+  assert.deepStrictEqual(h.events.record, ['start:teamsish.exe', 'stop:call-ended']);
+  assert.strictEqual(h.svc.getState().busy, true, 'still busy — Discord never let go of the mic');
+
+  h.feed('{"active":false,"apps":[]}');
+  assert.strictEqual(h.svc.getState().busy, false);
+  assert.strictEqual(h.events.light[h.events.light.length - 1], 'off');
+  assert.strictEqual(h.events.mqtt[h.events.mqtt.length - 1], 'OFF');
+});
+
+test('the opening idle baseline is still ignored', () => {
+  // Guards the comment at main.js:2433 — treating a startup baseline as "call ended" once split
+  // recordings into two files.
+  const h = harness();
+  h.recorder.recording = true;
+  h.feed('{"active":false,"apps":[]}');
+  assert.strictEqual(h.recorder.recording, true, 'a first-line idle must not stop a live recording');
+  assert.deepStrictEqual(h.events.record, []);
+});
+
+test('with the feature off, the monitor argv is byte-identical to today', () => {
+  assert.strictEqual(
+    monitorAllowlist('Zoom.exe,Teams.exe,ms-teams.exe', 'Discord.exe,slack.exe', false),
+    'Zoom.exe,Teams.exe,ms-teams.exe');
+});
+
+test('a recording started manually keeps you busy after the call app lets go', () => {
+  const h = harness();
+  h.feed('{"active":true,"app":"teamsish.exe","apps":["teamsish.exe"]}');
+  h.svc.setRecording(true);
+  h.feed('{"active":false,"apps":[]}');
+  assert.strictEqual(h.svc.getState().busy, true);
+  assert.strictEqual(h.svc.getState().reason, 'recording');
+  h.svc.setRecording(false);
+  assert.strictEqual(h.svc.getState().busy, false);
+});
+
+test('a manual override from the panel beats the live call state', () => {
+  const h = harness();
+  h.feed('{"active":true,"app":"teamsish.exe","apps":["teamsish.exe"]}');
+  assert.strictEqual(h.svc.getState().busy, true);
+  h.svc.setOverride('free');
+  assert.strictEqual(h.svc.getState().busy, false, 'forced free during a live call');
+  h.svc.setOverride('auto');
+  assert.strictEqual(h.svc.getState().busy, true, 'and back, because the call never ended');
+});

--- a/test/presenceMqtt.test.js
+++ b/test/presenceMqtt.test.js
@@ -1,0 +1,228 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  createPresenceMqtt, buildTopics, buildDiscoveryConfig, buildPayloads, safeNodeId, OBJECT_ID,
+} = require('../app/presenceMqtt');
+
+test('safeNodeId makes a hostname safe for both MQTT topics and HA object ids', () => {
+  assert.strictEqual(safeNodeId('TJ-Desktop'), 'tj-desktop');
+  assert.strictEqual(safeNodeId('host.with.dots'), 'host-with-dots');
+  // '+' and '#' are MQTT wildcards; '/' a level separator. None may survive into a topic.
+  assert.strictEqual(safeNodeId('we+ird/name#1'), 'we-ird-name-1');
+  assert.strictEqual(safeNodeId(''), 'open-quake');
+  assert.strictEqual(safeNodeId(null), 'open-quake');
+});
+
+test('topics are built under the configured base and share one node id', () => {
+  const t = buildTopics('open-quake', 'TJ-PC');
+  assert.strictEqual(t.node, 'tj-pc');
+  assert.strictEqual(t.state, 'open-quake/tj-pc/busy');
+  assert.strictEqual(t.attributes, 'open-quake/tj-pc/attributes');
+  assert.strictEqual(t.availability, 'open-quake/tj-pc/availability');
+  assert.strictEqual(t.discovery, 'homeassistant/binary_sensor/tj-pc_open_quake_busy/config');
+});
+
+test('stray slashes in the base topic do not produce empty topic levels', () => {
+  const t = buildTopics('/oq/', 'pc');
+  assert.strictEqual(t.state, 'oq/pc/busy');
+  assert.strictEqual(buildTopics('', 'pc').state, 'open-quake/pc/busy');
+});
+
+test('discovery config carries what HA needs to auto-create a persistent entity', () => {
+  const t = buildTopics('open-quake', 'pc');
+  const c = buildDiscoveryConfig(t, {});
+  assert.strictEqual(c.state_topic, t.state);
+  assert.strictEqual(c.availability_topic, t.availability);
+  assert.strictEqual(c.json_attributes_topic, t.attributes);
+  assert.strictEqual(c.payload_on, 'ON');
+  assert.strictEqual(c.payload_off, 'OFF');
+  assert.strictEqual(c.payload_available, 'online');
+  assert.strictEqual(c.payload_not_available, 'offline');
+  // unique_id is what makes the entity editable in the HA UI and stable across restarts.
+  assert.strictEqual(c.unique_id, 'pc_' + OBJECT_ID);
+  assert.ok(c.device && Array.isArray(c.device.identifiers), 'grouped under one device, not loose');
+});
+
+test('busy and free map to the documented payloads with attributes', () => {
+  const busy = buildPayloads({ busy: true, reason: 'call', app: 'Teams.exe', since: 1700000000000, recording: false, override: 'auto' });
+  assert.strictEqual(busy.state, 'ON');
+  assert.strictEqual(busy.attributes.reason, 'call');
+  assert.strictEqual(busy.attributes.app, 'Teams.exe');
+  assert.strictEqual(busy.attributes.since, new Date(1700000000000).toISOString());
+
+  const free = buildPayloads({ busy: false, reason: null, app: null, since: null });
+  assert.strictEqual(free.state, 'OFF');
+  assert.strictEqual(free.attributes.reason, null);
+  assert.strictEqual(free.attributes.since, null);
+});
+
+// ---- client behaviour against a fake mqtt module ----
+
+function fakeMqtt() {
+  const published = [];
+  const handlers = {};
+  let opts = null;
+  let ended = false;
+  const client = {
+    publish: (topic, payload, o) => published.push({ topic, payload, opts: o }),
+    on: (ev, fn) => { (handlers[ev] = handlers[ev] || []).push(fn); },
+    end: () => { ended = true; },
+  };
+  return {
+    connect: (url, o) => { opts = Object.assign({ url }, o); return client; },
+    _fire: (ev, arg) => (handlers[ev] || []).forEach(fn => fn(arg)),
+    _published: published,
+    _opts: () => opts,
+    _ended: () => ended,
+    _handlers: handlers,
+  };
+}
+
+function svcWith(mqtt, over) {
+  const s = createPresenceMqtt({ mqtt, hostname: 'tj-pc' });
+  s.apply(Object.assign({ enabled: true, url: 'mqtt://broker:1883', baseTopic: 'open-quake' }, over || {}));
+  return s;
+}
+
+test('THE WILL is registered at connect — the whole crash failsafe depends on it', () => {
+  const mqtt = fakeMqtt();
+  svcWith(mqtt);
+  const will = mqtt._opts().will;
+  assert.ok(will, 'a will must be registered');
+  assert.strictEqual(will.topic, 'open-quake/tj-pc/availability');
+  assert.strictEqual(will.payload, 'offline');
+  assert.strictEqual(will.retain, true);
+});
+
+test('on connect it announces discovery, availability, then state', () => {
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt);
+  s.publishState({ busy: true, reason: 'call', app: 'Teams.exe', since: 1 });
+  mqtt._published.length = 0;
+  mqtt._fire('connect');
+  const topics = mqtt._published.map(p => p.topic);
+  assert.ok(topics.includes('homeassistant/binary_sensor/tj-pc_open_quake_busy/config'));
+  assert.ok(topics.includes('open-quake/tj-pc/availability'));
+  assert.ok(topics.includes('open-quake/tj-pc/busy'), 'current state replayed, not just discovery');
+});
+
+test('a reconnect re-announces, because a broker restart drops retained messages', () => {
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt);
+  mqtt._fire('connect');
+  s.publishState({ busy: true, reason: 'call', app: 'Zoom.exe', since: 1 });
+  mqtt._published.length = 0;
+  mqtt._fire('connect');   // MQTT.js re-emits connect after an automatic reconnect
+  const topics = mqtt._published.map(p => p.topic);
+  assert.ok(topics.includes('homeassistant/binary_sensor/tj-pc_open_quake_busy/config'),
+    'entity heals itself rather than sitting unavailable until the next transition');
+  assert.strictEqual(mqtt._published.find(p => p.topic === 'open-quake/tj-pc/busy').payload, 'ON');
+});
+
+test('state and attributes are published retained so HA survives a restart', () => {
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt);
+  mqtt._fire('connect');
+  mqtt._published.length = 0;
+  s.publishState({ busy: true, reason: 'recording', app: null, since: 1700000000000, recording: true });
+  const state = mqtt._published.find(p => p.topic === 'open-quake/tj-pc/busy');
+  const attrs = mqtt._published.find(p => p.topic === 'open-quake/tj-pc/attributes');
+  assert.strictEqual(state.payload, 'ON');
+  assert.strictEqual(state.opts.retain, true);
+  assert.strictEqual(JSON.parse(attrs.payload).reason, 'recording');
+});
+
+test('a broker error never throws — a bad address must not kill the app', () => {
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt);
+  assert.ok(mqtt._handlers.error && mqtt._handlers.error.length, 'an error handler must be attached');
+  assert.doesNotThrow(() => mqtt._fire('error', new Error('ECONNREFUSED')));
+  assert.strictEqual(s.status().connected, false);
+  assert.match(s.status().error, /ECONNREFUSED/);
+});
+
+test('a clean stop says offline immediately rather than waiting for the will', () => {
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt);
+  mqtt._fire('connect');
+  mqtt._published.length = 0;
+  s.stop();
+  const bye = mqtt._published.find(p => p.topic === 'open-quake/tj-pc/availability');
+  assert.strictEqual(bye.payload, 'offline');
+  assert.strictEqual(mqtt._ended(), true);
+});
+
+test('re-applying identical settings does NOT reconnect', () => {
+  // Reconnecting drops and re-registers the will. Editing an unrelated setting must not disturb it.
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt);
+  mqtt._fire('connect');
+  mqtt._published.length = 0;
+  s.apply({ enabled: true, url: 'mqtt://broker:1883', baseTopic: 'open-quake' });
+  assert.strictEqual(mqtt._ended(), false, 'connection kept');
+  assert.strictEqual(mqtt._published.length, 0, 'nothing re-announced');
+});
+
+test('changing the broker URL disconnects A and connects to B', () => {
+  // The realistic path: type the wrong broker, save, notice, fix it. Without an explicit disconnect
+  // the user stays bound to the first (failed) client and the fix appears to do nothing.
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt, { url: 'mqtt://wrong-host:1883' });
+  mqtt._fire('connect');
+  assert.strictEqual(mqtt._opts().url, 'mqtt://wrong-host:1883');
+
+  s.apply({ enabled: true, url: 'mqtt://right-host:1883', baseTopic: 'open-quake' });
+  assert.strictEqual(mqtt._ended(), true, 'the old client must be ended');
+  assert.strictEqual(mqtt._opts().url, 'mqtt://right-host:1883', 'reconnected to the new broker');
+  // The new connection must carry its own will; a reconnect that lost it would silently drop the
+  // crash failsafe.
+  assert.strictEqual(mqtt._opts().will.topic, 'open-quake/tj-pc/availability');
+});
+
+test('changing only the credentials also reconnects', () => {
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt, { username: 'old' });
+  mqtt._fire('connect');
+  s.apply({ enabled: true, url: 'mqtt://broker:1883', baseTopic: 'open-quake', username: 'new', password: 'pw' });
+  assert.strictEqual(mqtt._opts().username, 'new');
+  assert.strictEqual(mqtt._opts().password, 'pw');
+});
+
+test('changing the base topic re-homes every topic', () => {
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt);
+  mqtt._fire('connect');
+  s.apply({ enabled: true, url: 'mqtt://broker:1883', baseTopic: 'presence' });
+  mqtt._published.length = 0;
+  mqtt._fire('connect');
+  assert.ok(mqtt._published.some(p => p.topic === 'presence/tj-pc/busy'));
+  assert.strictEqual(mqtt._opts().will.topic, 'presence/tj-pc/availability');
+});
+
+test('disabling stops the client and reports disabled', () => {
+  const mqtt = fakeMqtt();
+  const s = svcWith(mqtt);
+  mqtt._fire('connect');
+  s.apply({ enabled: false });
+  assert.strictEqual(mqtt._ended(), true);
+  assert.strictEqual(s.status().enabled, false);
+});
+
+test('enabled with no broker URL reports the reason instead of connecting', () => {
+  const mqtt = fakeMqtt();
+  const s = createPresenceMqtt({ mqtt, hostname: 'tj-pc' });
+  s.apply({ enabled: true, url: '' });
+  assert.strictEqual(mqtt._opts(), null, 'no connection attempted');
+  assert.match(s.status().error, /broker URL required/);
+});
+
+test('publishState before a connection is a no-op, and replays on connect', () => {
+  const mqtt = fakeMqtt();
+  const s = createPresenceMqtt({ mqtt, hostname: 'tj-pc' });
+  assert.strictEqual(s.publishState({ busy: true, reason: 'call' }), false);
+  s.apply({ enabled: true, url: 'mqtt://broker:1883', baseTopic: 'open-quake' });
+  mqtt._fire('connect');
+  assert.ok(mqtt._published.some(p => p.topic === 'open-quake/tj-pc/busy'),
+    'the state held before connecting is announced once connected');
+});

--- a/test/presenceService.test.js
+++ b/test/presenceService.test.js
@@ -1,0 +1,199 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { createPresenceService, wledUrl, wledBody } = require('../app/presenceService');
+
+test('wledUrl accepts a bare IP, a host:port, and a full URL', () => {
+  // Users type a bare LAN IP. Rejecting that instead of defaulting the scheme would read as "broken".
+  assert.strictEqual(wledUrl('192.168.1.50', '/json/state'), 'http://192.168.1.50/json/state');
+  assert.strictEqual(wledUrl('192.168.1.50:8080', '/json/state'), 'http://192.168.1.50:8080/json/state');
+  assert.strictEqual(wledUrl('http://wled.local/', '/json/state'), 'http://wled.local/json/state');
+  assert.strictEqual(wledUrl('', '/json/state'), null);
+});
+
+test('wledBody sends brightness with the colour, not just the colour', () => {
+  // WLED gotcha: turning on from off and setting a colour in one request can be ignored unless
+  // brightness is sent explicitly.
+  const on = wledBody({ r: 255, g: 0, b: 0 }, true);
+  assert.strictEqual(on.on, true);
+  assert.strictEqual(on.bri, 255);
+  assert.deepStrictEqual(on.seg[0].col[0], [255, 0, 0]);
+  assert.deepStrictEqual(wledBody({ r: 0, g: 0, b: 0 }, false), { on: false });
+});
+
+// ---- orchestration, with every output faked ----
+
+function fakes() {
+  const light = { calls: [], closed: 0 };
+  const busylight = {
+    setColor: c => { light.calls.push(c); return true; },
+    off: () => { light.calls.push('off'); return true; },
+    close: () => { light.closed++; },
+    status: () => ({ connected: true, product: 'BUSYLIGHT OMEGA', error: null }),
+    isConnected: () => true,
+    detect: () => ({ found: true }),
+  };
+  const published = [];
+  const mqtt = {
+    apply: s => published.push(['apply', s]),
+    publishState: s => { published.push(['state', s.busy, s.reason]); return true; },
+    status: () => ({ enabled: true, connected: true, error: null }),
+    stop: () => published.push(['stop']),
+  };
+  return { busylight, mqtt, light, published };
+}
+
+function svc(over, f) {
+  const k = f || fakes();
+  const s = createPresenceService({ busylight: k.busylight, mqtt: k.mqtt, fetch: null });
+  s.applySettings(Object.assign({
+    busyEnabled: true, busyLightEnabled: true, busyOffDelaySec: 0,
+    busyLightBusyColor: '#ff0000', busyLightFreeColor: '#00ff00', busyLightFreeOff: true,
+  }, over || {}));
+  return { s, k };
+}
+
+test('a call turns the light to the busy colour and publishes ON', () => {
+  const { s, k } = svc();
+  k.light.calls.length = 0; k.published.length = 0;
+  s.setCall(true, 'Teams.exe');
+  assert.deepStrictEqual(k.light.calls[0], { r: 255, g: 0, b: 0 });
+  assert.deepStrictEqual(k.published.find(p => p[0] === 'state').slice(1), [true, 'call']);
+  assert.strictEqual(s.getState().app, 'Teams.exe');
+});
+
+test('free with "light off" writes off rather than a colour', () => {
+  const { s, k } = svc();
+  s.setCall(true, 'Teams.exe');
+  k.light.calls.length = 0;
+  s.setCall(false, null);
+  assert.strictEqual(k.light.calls[0], 'off');
+  assert.strictEqual(s.getState().busy, false);
+});
+
+test('free with a free colour writes that colour instead', () => {
+  const { s, k } = svc({ busyLightFreeOff: false });
+  s.setCall(true, 'Teams.exe');
+  k.light.calls.length = 0;
+  s.setCall(false, null);
+  assert.deepStrictEqual(k.light.calls[0], { r: 0, g: 255, b: 0 });
+});
+
+test('brightness scales the colour actually written', () => {
+  const { s, k } = svc({ busyLightBrightness: 50 });
+  k.light.calls.length = 0;
+  s.setCall(true, 'Teams.exe');
+  assert.deepStrictEqual(k.light.calls[0], { r: 128, g: 0, b: 0 });
+});
+
+test('recording alone makes you busy', () => {
+  const { s, k } = svc();
+  k.published.length = 0;
+  s.setRecording(true);
+  assert.strictEqual(s.getState().busy, true);
+  assert.strictEqual(s.getState().reason, 'recording');
+});
+
+test('a manual override drives the outputs and survives a call ending', () => {
+  const { s } = svc();
+  s.setOverride('busy');
+  assert.strictEqual(s.getState().busy, true);
+  assert.strictEqual(s.getState().reason, 'manual');
+  s.setCall(true, 'Teams.exe');
+  s.setCall(false, null);
+  assert.strictEqual(s.getState().busy, true, 'the override still holds');
+  s.setOverride('auto');
+  assert.strictEqual(s.getState().busy, false);
+});
+
+test('turning the light off in settings actively clears it', () => {
+  // Otherwise whatever it last showed stays lit until the device's own 30s timeout, which reads as
+  // "I disabled it and it is still red".
+  const f = fakes();
+  const { s } = svc({}, f);
+  s.setCall(true, 'Teams.exe');
+  const before = f.busylight.close ? f.light.closed : 0;
+  s.applySettings({ busyEnabled: true, busyLightEnabled: false });
+  assert.ok(f.light.closed > before, 'the light was explicitly closed');
+});
+
+test('disabling the whole feature stops driving the light', () => {
+  const f = fakes();
+  const { s } = svc({}, f);
+  s.applySettings({ busyEnabled: false });
+  f.light.calls.length = 0;
+  s.setCall(true, 'Teams.exe');
+  assert.strictEqual(f.light.calls.length, 0, 'no writes while disabled');
+});
+
+test('a light that throws does not stop MQTT from being published', () => {
+  // The isolation rule: one dead output must never take another down.
+  const f = fakes();
+  f.busylight.setColor = () => { throw new Error('device exploded'); };
+  const { s } = svc({}, f);
+  f.published.length = 0;
+  assert.doesNotThrow(() => s.setCall(true, 'Teams.exe'));
+  assert.ok(f.published.some(p => p[0] === 'state' && p[1] === true), 'MQTT still got the state');
+  assert.match(s.getState().outputs.light.status, /device exploded/);
+});
+
+test('an MQTT publish that throws does not stop the light', () => {
+  const f = fakes();
+  f.mqtt.publishState = () => { throw new Error('broker gone'); };
+  const { s } = svc({}, f);
+  f.light.calls.length = 0;
+  assert.doesNotThrow(() => s.setCall(true, 'Teams.exe'));
+  assert.deepStrictEqual(f.light.calls[0], { r: 255, g: 0, b: 0 }, 'the light still went red');
+});
+
+test('stop clears the light and tells HA we are gone', () => {
+  const f = fakes();
+  const { s } = svc({}, f);
+  s.setCall(true, 'Teams.exe');
+  s.stop();
+  assert.ok(f.light.closed > 0, 'light cleared immediately, not left to the 30s timeout');
+  assert.ok(f.published.some(p => p[0] === 'stop'), 'HA told explicitly rather than via the will');
+});
+
+test('getState reports per-output status for the settings page', () => {
+  const { s } = svc();
+  const st = s.getState();
+  assert.strictEqual(st.enabled, true);
+  assert.ok(st.outputs.light, 'light status present');
+  assert.ok(st.outputs.wled, 'wled status present');
+  assert.ok(st.outputs.mqtt, 'mqtt status present');
+});
+
+test('the off-delay holds the light on across a brief mic drop', async () => {
+  const f = fakes();
+  const s = createPresenceService({ busylight: f.busylight, mqtt: f.mqtt, fetch: null });
+  s.applySettings({ busyEnabled: true, busyLightEnabled: true, busyOffDelaySec: 1, busyLightBusyColor: '#ff0000' });
+  s.setCall(true, 'Teams.exe');
+  f.light.calls.length = 0;
+  s.setCall(false, null);
+  assert.strictEqual(s.getState().busy, true, 'still busy immediately after the drop');
+  s.setCall(true, 'Teams.exe');   // mic retaken inside the window
+  await new Promise(r => setTimeout(r, 1200));
+  assert.strictEqual(s.getState().busy, true, 'never went free');
+  s.stop();
+});
+
+test('custom mode paints the user-picked colour, ordinary busy does not', () => {
+  const f = fakes();
+  const { s } = svc({ busyManualColor: '#a020f0' }, f);
+  f.light.calls.length = 0;
+  s.setOverride('custom');
+  assert.deepStrictEqual(f.light.calls[0], { r: 160, g: 32, b: 240 }, 'custom colour');
+  f.light.calls.length = 0;
+  s.setOverride('busy');
+  assert.deepStrictEqual(f.light.calls[0], { r: 255, g: 0, b: 0 }, 'plain busy stays red');
+});
+
+test('setManualColor applies immediately while custom is active', () => {
+  const f = fakes();
+  const { s } = svc({ busyManualColor: '#a020f0' }, f);
+  s.setOverride('custom');
+  f.light.calls.length = 0;
+  s.setManualColor('#00c853');
+  assert.deepStrictEqual(f.light.calls[0], { r: 0, g: 200, b: 83 });
+});


### PR DESCRIPTION
Turns a busy light red while a call app holds the microphone (or open-quake is recording), replacing Kuando's own "Busylight for UC" software. Off by default; nothing changes for anyone who leaves it off.

## Outputs

Three, each independently toggled and independently failure-isolated — a dead broker, an unplugged light and a mistyped WLED address are normal conditions, not incidents:

- **Kuando Busylight** over USB HID (`node-hid`, already a dependency — no new native build)
- **WLED** over HTTP, for a DIY ESP32 light
- **Home Assistant** via MQTT discovery, creating `binary_sensor.open_quake_busy` with no HA-side configuration

## The native monitor's contract changed

`mic-session-monitor` now emits every allowlisted process holding a capture session, not just the first:

```json
{"active":true,"app":"Teams.exe","apps":["Teams.exe","Discord.exe"]}
```

Windows shared-mode capture lets several apps hold one microphone at once — which is also why the recorder can capture your mic while Teams is in a call. Once a busy-only app (Discord, Slack) shares the allowlist, reporting only the first match broke two things:

- reading `app` gave whichever process endpoint enumeration reached first, so **Discord idling on the mic made a Teams call invisible and auto-record never started**
- keying auto-stop off the top-level `active` flag **never fired while Discord stayed open**, so recordings ran to the silence timer

Both consumers now filter `apps[]` against their own list (`app/micMonitorRouting.js`), and the emit condition compares the whole match set — a call app joining an already-busy microphone leaves the first match unchanged, so watching only that emits nothing at all.

`app` is retained so nothing that still reads it crashes, but no code reads it any more.

## Failsafes

Both ends fail safe by construction rather than by remembering to run cleanup:

- the Busylight extinguishes itself ~30s after keep-alives stop
- the MQTT **last will** marks the HA entity unavailable

Killing open-quake, or losing power, cannot leave you showing busy.

## Also

- Panel **Busy** column: Auto / Busy / Free / Custom, with a colour picker for Custom, and a red ring on the top-bar chip so state reads with the column closed
- Optional **schedule** restricting the USB light to chosen days and hours, including overnight windows — where the window belongs to the day it *started*, so Friday 22:00–06:00 covers 01:00 Saturday without ticking Saturday
- `busyMqttPassword` registered in `secretStore` so it is DPAPI-encrypted at rest

## Verification

Verified against a real **Busylight UC Omega**, which enumerates as `0x27BB:0x3BCF` — not the `0x3BCD` every reference documents. That is why the driver matches on vendor id alone; hardcoding the documented product id finds no device.

The `apps[]` behaviour was reproduced with two processes holding the same physical microphone simultaneously, and `test/presenceIntegration.test.js` replays that captured output through the real routing and state machine.

**118 new tests.** `test/meetingDefaultsSync.test.js` asserts the C# source still honours the `apps[]` contract, because every other test runs on captured strings and cannot detect a reverted helper.

## Known

- One pre-existing test failure in `config.js`'s save path (expects an older status string). Present on `main` too; deliberately not folded into this branch.
