### PR TITLE
test: unpin the save-failure assertion from exact footer copy

### DIFF
--- a/test/githubEditorSettings.test.js
+++ b/test/githubEditorSettings.test.js
@@ -29,9 +29,15 @@ test('editor surfaces GitHub validation failures instead of misreporting secret 
   const source = read('config.js');
   const save = source.slice(source.indexOf('async function doSave'), source.indexOf('// ---- tiles / icons'));
   assert.match(save, /result && result\.error/);
-  assert.match(save, /setState\('save failed: ' \+ reason/);
+  // Assert the SHAPE, not the copy: the failing reason must be interpolated into whatever the footer
+  // says, rather than the footer hardcoding one cause. Pinning the exact prefix is what rotted this
+  // test — 50c65c7 renamed 'save failed: ' to 'Unable to apply changes: ' to match the footer states
+  // in docs/editor-design-system.md, and the assertion was left behind, red on main ever since.
+  assert.match(save, /setState\('[^']*' \+ reason/);
   assert.match(save, /detail === 'secure persistence failed'/);
-  assert.doesNotMatch(save, /setState\('save failed: secrets could not be stored securely'/);
+  // The point of the test: a GitHub validation failure must surface as ITSELF, so the secret-storage
+  // wording may only ever be a computed fallback, never a literal handed straight to setState.
+  assert.doesNotMatch(save, /setState\('[^']*secrets could not be stored securely'/);
 });
 
 test('GitHub editor bridge is narrow and tokens remain main-process-only', () => {


### PR DESCRIPTION
`config.js` was never broken — the test was. This changes the test only.

## What was wrong

`test/githubEditorSettings.test.js` asserted on the exact footer copy:

```js
assert.match(save, /setState\('save failed: ' \+ reason/);
```

Commit `50c65c7` deliberately renamed the editor's save states to match the footer states in `docs/editor-design-system.md` — `'save failed: '` became `'Unable to apply changes: '`. No commit ever updated the assertion, so a deliberate copy improvement has read as a test failure on `main` ever since.

## The fix

Assert the **shape** rather than the wording:

```js
assert.match(save, /setState\('[^']*' \+ reason/);
assert.doesNotMatch(save, /setState\('[^']*secrets could not be stored securely'/);
```

The computed reason must reach the footer, and the secret-storage message may only ever be a computed fallback — never a literal handed straight to `setState`.

That preserves exactly what the test exists to prove (a GitHub validation failure surfaces as *itself*, not as a misleading secrets error) while surviving the next copy edit, which is precisely what rotted it.

## Verification

Not trusted on green alone. Both regressions the test guards were reintroduced against the fixed test:

| Change to `config.js` | Result |
|---|---|
| Hardcode `'…secrets could not be stored securely'` instead of the reason | **fails** ✓ |
| Drop the reason: `setState('Unable to apply changes', 'dirty')` | **fails** ✓ |
| Restored | passes |

Suite is now **711/711**, the first fully green run.
